### PR TITLE
Add PicoPass (iCLASS) reader for POOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ managed_components/
 .DS_Store
 *.swp
 *.swo
+.cache/
+sdkconfig.defaults.local

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(MODULES
     poom_breakout
     poom_menu
     poom_nfc
+    poom_picopass
     poom_motion_midi
     poom_ble_hid
     poom_ble_keyboard
@@ -199,6 +200,7 @@ set(POOM_APPLICATION_DIRS
     ${CMAKE_SOURCE_DIR}/applications/poom_breakout
     ${CMAKE_SOURCE_DIR}/applications/poom_menu
     ${CMAKE_SOURCE_DIR}/applications/poom_nfc
+    ${CMAKE_SOURCE_DIR}/applications/poom_picopass
     ${CMAKE_SOURCE_DIR}/applications/poom_motion_midi
     ${CMAKE_SOURCE_DIR}/applications/poom_ble_hid
     ${CMAKE_SOURCE_DIR}/applications/poom_ble_keyboard

--- a/applications/poom_app_pack/CMakeLists.txt
+++ b/applications/poom_app_pack/CMakeLists.txt
@@ -27,6 +27,7 @@ set(POOM_APP_PACK_REQUIRES
     i2c
     ir
     poom_nfc
+    poom_picopass
     poom_motion_midi
     poom_ble_keyboard
     poom_ble_plot

--- a/applications/poom_app_pack/include/menu_picopass.h
+++ b/applications/poom_app_pack/include/menu_picopass.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Device-menu entry for the PicoPass reader.
+
+#ifndef MENU_PICOPASS_H
+#define MENU_PICOPASS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void menu_picopass_show(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MENU_PICOPASS_H */

--- a/applications/poom_app_pack/src/menu_picopass.c
+++ b/applications/poom_app_pack/src/menu_picopass.c
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Device-menu entry for the PicoPass reader. Opens a submenu (Read for now),
+// modeled on menu_nfc / menu_fw_info.
+
+#include "menu_picopass.h"
+#include "poom_picopass.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "Arduboy2.h"
+#include "button_driver.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "input_events.h"
+#include "poom_sbus.h"
+
+#define POOM_MENU_RESUME_TOPIC   "poom/menu/resume"
+#define MENU_PICOPASS_REFRESH_MS (150U)
+#define MENU_PICOPASS_POLL_MS    (120U)  // gap between read attempts while polling
+#define MENU_PICOPASS_STACK      (8192U)  // read flow + loclass/DES need the stack
+#define MENU_PICOPASS_PRIO       (4U)
+
+#define MAIN_LIST_Y0      (16)
+#define MAIN_ROW_STEP     (11)
+#define MAIN_ROW_HILITE_H (9)
+
+#ifndef BTN_A
+#define BTN_A (0U)
+#endif
+#ifndef BTN_B
+#define BTN_B (1U)
+#endif
+#ifndef BTN_UP
+#define BTN_UP (4U)
+#endif
+#ifndef BTN_DOWN
+#define BTN_DOWN (5U)
+#endif
+#ifndef BUTTON_SINGLE_CLICK
+#define BUTTON_SINGLE_CLICK (4U)
+#endif
+
+typedef struct
+{
+    uint8_t button;
+    uint8_t event;
+    uint32_t ts_ms;
+} menu_picopass_button_msg_t;
+
+typedef enum
+{
+    PP_MENU,
+    PP_READING,
+    PP_RESULT
+} pp_state_t;
+
+// Submenu options. Add real entries (Emulate, Write, ...) here as they land.
+typedef enum
+{
+    PP_OPT_READ = 0,
+    PP_OPT_COUNT
+} pp_opt_t;
+static const char* const k_opt_labels[PP_OPT_COUNT] = {"Read"};
+
+static bool s_active                  = false;
+static bool s_buttons_subscribed      = false;
+static volatile bool s_exit_requested = false;
+static volatile bool s_cancel_read = false;  // B while reading: back to submenu
+static TaskHandle_t s_task         = NULL;
+static char s_sbus_user[]          = "menu_picopass";
+
+static pp_state_t s_state          = PP_MENU;
+static pp_opt_t s_opt              = PP_OPT_READ;
+static PoomPicopassStatus s_status = PoomPicopassOk;
+static PoomPicopassDump s_dump;
+
+static void menu_picopass_button_cb_(const poom_sbus_msg_t* msg,
+                                     void* user_ctx);
+static void menu_picopass_task_(void* arg);
+
+static const char* status_short(PoomPicopassStatus s)
+{
+    switch(s)
+    {
+        case PoomPicopassErrSelect:
+            return "Select fail";
+        case PoomPicopassErrReadCheck:
+            return "RdChk fail";
+        case PoomPicopassErrAuth:
+            return "Auth fail";
+        case PoomPicopassErrRead:
+            return "Read fail";
+        case PoomPicopassErrInit:
+            return "NFC init fail";
+        default:
+            return "Error";
+    }
+}
+
+// A card is "not present yet" (keep polling) vs a hard failure worth reporting.
+static bool status_is_no_card(PoomPicopassStatus s)
+{
+    return (s == PoomPicopassErrNoCard) || (s == PoomPicopassErrIdentify);
+}
+
+static void pp_draw_header_(void)
+{
+    poom_arduboy_set_text_size(1);
+    poom_arduboy_set_cursor(28, 2);
+    (void)poom_arduboy_print(F("PICOPASS"));
+    poom_arduboy_fill_rect(0, 0, ARDUBOY_WIDTH, 11, INVERT);
+}
+
+static void pp_draw_(void)
+{
+    poom_arduboy_clear();
+    pp_draw_header_();
+
+    if(s_state == PP_MENU)
+    {
+        for(int row = 0; row < (int)PP_OPT_COUNT; row++)
+        {
+            const int16_t y =
+                (int16_t)(MAIN_LIST_Y0 + (int16_t)row * MAIN_ROW_STEP);
+            poom_arduboy_set_cursor(4, y);
+            (void)poom_arduboy_print(k_opt_labels[row]);
+            if(row == (int)s_opt)
+            {
+                poom_arduboy_fill_rect(0, (int16_t)(y - 1), ARDUBOY_WIDTH,
+                                       MAIN_ROW_HILITE_H, INVERT);
+            }
+        }
+        poom_arduboy_set_cursor(0, 56);
+        (void)poom_arduboy_print(F("A:SEL"));
+        poom_arduboy_set_cursor(72, 56);
+        (void)poom_arduboy_print(F("B:EXIT"));
+    }
+    else if(s_state == PP_READING)
+    {
+        poom_arduboy_set_cursor(0, 24);
+        (void)poom_arduboy_print(F("Reading..."));
+        poom_arduboy_set_cursor(0, 34);
+        (void)poom_arduboy_print(F("Present a card"));
+        poom_arduboy_set_cursor(0, 56);
+        (void)poom_arduboy_print(F("B:CANCEL"));
+    }
+    else
+    {  // PP_RESULT
+        char l[24];
+        if(s_status != PoomPicopassOk && s_status != PoomPicopassErrAuth)
+        {
+            poom_arduboy_set_cursor(0, 24);
+            (void)poom_arduboy_print(status_short(s_status));
+        }
+        else
+        {
+            (void)snprintf(l, sizeof(l), "CSN:%02X%02X%02X%02X%02X%02X%02X%02X",
+                           s_dump.csn[0], s_dump.csn[1], s_dump.csn[2],
+                           s_dump.csn[3], s_dump.csn[4], s_dump.csn[5],
+                           s_dump.csn[6], s_dump.csn[7]);
+            poom_arduboy_set_cursor(0, 16);
+            (void)poom_arduboy_print(l);
+
+            if(s_dump.pacs_present)
+            {
+                (void)snprintf(l, sizeof(l), "BITS:%u", s_dump.bit_length);
+                poom_arduboy_set_cursor(0, 30);
+                (void)poom_arduboy_print(l);
+                (void)snprintf(l, sizeof(l), "%02X%02X%02X%02X%02X%02X%02X%02X",
+                               s_dump.credential[0], s_dump.credential[1],
+                               s_dump.credential[2], s_dump.credential[3],
+                               s_dump.credential[4], s_dump.credential[5],
+                               s_dump.credential[6], s_dump.credential[7]);
+                poom_arduboy_set_cursor(0, 42);
+                (void)poom_arduboy_print(l);
+            }
+        }
+        poom_arduboy_set_cursor(0, 56);
+        (void)poom_arduboy_print(F("A:AGAIN"));
+        poom_arduboy_set_cursor(72, 56);
+        (void)poom_arduboy_print(F("B:BACK"));
+    }
+    poom_arduboy_display();
+}
+
+static void menu_picopass_exit_(void)
+{
+    TaskHandle_t current_task = xTaskGetCurrentTaskHandle();
+    s_active                  = false;
+    s_exit_requested          = false;
+
+    if(s_task != NULL)
+    {
+        if(s_task != current_task)
+        {
+            TaskHandle_t task = s_task;
+            s_task            = NULL;
+            vTaskDelete(task);
+        }
+        else
+        {
+            s_task = NULL;
+        }
+    }
+    if(s_buttons_subscribed)
+    {
+        (void)poom_sbus_unsubscribe_cb("input/button", menu_picopass_button_cb_,
+                                       s_sbus_user);
+        s_buttons_subscribed = false;
+    }
+    const uint8_t token = 1U;
+    (void)poom_sbus_publish(POOM_MENU_RESUME_TOPIC, &token, sizeof(token), 0);
+}
+
+static void menu_picopass_button_cb_(const poom_sbus_msg_t* msg, void* user_ctx)
+{
+    (void)user_ctx;
+    if((msg == NULL) || (msg->len < sizeof(menu_picopass_button_msg_t)))
+        return;
+    menu_picopass_button_msg_t ev;
+    (void)memcpy(&ev, msg->data, sizeof(ev));
+    if(ev.event != BUTTON_SINGLE_CLICK)
+        return;
+
+    if(s_state == PP_MENU)
+    {
+        if(ev.button == BTN_B)
+        {
+            s_exit_requested = true;
+        }
+        else if(ev.button == BTN_UP)
+        {
+            if((int)s_opt > 0)
+                s_opt = (pp_opt_t)((int)s_opt - 1);
+        }
+        else if(ev.button == BTN_DOWN)
+        {
+            if(((int)s_opt + 1) < (int)PP_OPT_COUNT)
+                s_opt = (pp_opt_t)((int)s_opt + 1);
+        }
+        else if(ev.button == BTN_A)
+        {
+            if(s_opt == PP_OPT_READ)
+            {
+                s_cancel_read = false;
+                s_state       = PP_READING;
+            }
+        }
+    }
+    else if(s_state == PP_READING)
+    {
+        if(ev.button == BTN_B)
+            s_cancel_read = true;  // stop polling, back to submenu
+    }
+    else if(s_state == PP_RESULT)
+    {
+        if(ev.button == BTN_B)
+        {
+            s_state = PP_MENU;
+        }
+        else if(ev.button == BTN_A)
+        {
+            s_cancel_read = false;
+            s_state       = PP_READING;
+        }
+    }
+}
+
+static void menu_picopass_task_(void* arg)
+{
+    (void)arg;
+    while(s_active)
+    {
+        if(s_exit_requested)
+        {
+            menu_picopass_exit_();
+            break;
+        }
+
+        if(s_state == PP_READING)
+        {
+            // Retry until a card is found or the user cancels, so the card can
+            // be moved into the field.
+            pp_draw_();  // show "Reading..." before the (brief) blocking
+                         // attempt
+            s_status = poom_picopass_read(&s_dump, NULL, false);
+            if(s_cancel_read)
+            {
+                s_cancel_read = false;
+                s_state       = PP_MENU;
+            }
+            else if(s_status == PoomPicopassOk ||
+                    s_status == PoomPicopassErrAuth)
+            {
+                s_state = PP_RESULT;
+            }
+            else if(status_is_no_card(s_status))
+            {
+                vTaskDelay(
+                    pdMS_TO_TICKS(MENU_PICOPASS_POLL_MS));  // keep polling
+            }
+            else
+            {
+                s_state = PP_RESULT;  // hard error (init/select/etc): report it
+            }
+            continue;
+        }
+
+        pp_draw_();
+        vTaskDelay(pdMS_TO_TICKS(MENU_PICOPASS_REFRESH_MS));
+    }
+    s_task = NULL;
+    vTaskDelete(NULL);
+}
+
+void menu_picopass_show(void)
+{
+    if(s_task != NULL)
+        return;
+
+    s_active         = true;
+    s_exit_requested = false;
+    s_cancel_read    = false;
+    s_state          = PP_MENU;
+    s_opt            = PP_OPT_READ;
+
+    if(!s_buttons_subscribed)
+    {
+        if(poom_sbus_subscribe_cb("input/button", menu_picopass_button_cb_,
+                                  s_sbus_user))
+        {
+            s_buttons_subscribed = true;
+        }
+        else
+        {
+            s_active            = false;
+            const uint8_t token = 1U;
+            (void)poom_sbus_publish(POOM_MENU_RESUME_TOPIC, &token,
+                                    sizeof(token), 0);
+            return;
+        }
+    }
+
+    (void)xTaskCreate(menu_picopass_task_, "menu_picopass", MENU_PICOPASS_STACK,
+                      NULL, MENU_PICOPASS_PRIO, &s_task);
+}

--- a/applications/poom_menu/src/poom_menu.c
+++ b/applications/poom_menu/src/poom_menu.c
@@ -50,6 +50,7 @@
 #include "menu_midi.h"
 #include "menu_midi_harmony.h"
 #include "menu_nfc.h"
+#include "menu_picopass.h"
 #include "menu_nfc_tuning.h"
 #include "menu_plot.h"
 #include "menu_poom_pcap.h"
@@ -579,6 +580,13 @@ static void action_nfc_(void)
     menu_nfc_show();
 }
 
+static void action_picopass_(void)
+{
+    detach_menu_();
+    vTaskDelay(pdMS_TO_TICKS(180U));
+    menu_picopass_show();
+}
+
 /**
  * @brief Internal helper for `action_wii`.
  *
@@ -872,6 +880,7 @@ static const poom_menu_item_t s_apps_zen[] = {
 //    {"TONE", action_tone_},
     {"CONTROL", action_control_music_},
     {"NFC", action_nfc_},
+    {"PICOPASS", action_picopass_},
     {"IR UNIV", action_ir_universal_},
     {"POOM WEB", action_cli_web_},
 };

--- a/applications/poom_picopass/CMakeLists.txt
+++ b/applications/poom_picopass/CMakeLists.txt
@@ -1,0 +1,25 @@
+# PicoPass (HID iCLASS) reader library for POOM.
+#
+# Depends on the `nfcal` component, which provides ST's RFAL API
+# (rfal_rf.h, rfalSetMode, rfalTransceiveBlockingTxRx, ...), and `poom_nfc`
+# for bringing up the NFC core. DES/3DES are vendored (poom_des.c) because
+# ESP-IDF 6.1's mbedTLS dropped MBEDTLS_DES_C.
+
+idf_component_register(
+    SRCS
+        "src/rfal_picopass.c"
+        "src/poom_picopass.c"
+        "src/poom_des.c"
+        "src/loclass/optimized_cipher.c"
+        "src/loclass/optimized_cipherutils.c"
+        "src/loclass/optimized_ikeys.c"
+        "src/loclass/optimized_elite.c"
+    INCLUDE_DIRS
+        "include"
+    PRIV_INCLUDE_DIRS
+        "src"
+        "src/loclass"
+    REQUIRES
+        nfcal
+        poom_nfc
+)

--- a/applications/poom_picopass/README.md
+++ b/applications/poom_picopass/README.md
@@ -1,0 +1,84 @@
+# poom_picopass
+
+`poom_picopass` reads PicoPass / HID iCLASS cards on POOM's ST25R3916 RF
+frontend. It provides:
+
+- PicoPass anticollision and CSN read
+- standard-key authentication (CSN-diversified key + reader MAC)
+- authenticated read of the AA1 application area
+- PACS credential extraction (3DES transport-key decrypt, bit length + raw bytes)
+
+It reads standard-security iCLASS credentials for lab, diagnostics, and
+authorized development on ESP-IDF targets, through the `nfcal` component
+(RFAL/ST25R3916) hosted in `third-party/nfcal`.
+
+## Purpose
+
+This component contains the PicoPass-facing logic for:
+
+- PicoPass mode setup (`RFAL_MODE_POLL_PICOPASS`, 26.48 kbit/s, manual TX CRC)
+- ACTALL / IDENTIFY / SELECT / READCHECK / CHECK / READ framing and CRC
+- key diversification and reader-MAC authentication (loclass)
+- extracting the PACS credential from blocks 6-9 (3DES decrypt, Wiegand bit length, sentinel-stripped bytes)
+
+## Structure
+
+```text
+applications/poom_picopass
+├── include/
+│   └── poom_picopass.h        # read flow + dump types (public API)
+└── src/
+    ├── rfal_picopass.c        # low-level poller on ST RFAL
+    ├── rfal_picopass.h
+    ├── poom_picopass.c        # read flow + PACS decode
+    ├── poom_des.c/.h          # vendored single/3DES (Apache-2.0, from mbedTLS)
+    └── loclass/               # iCLASS cipher + keygen (GPL-3.0, from Proxmark3)
+        └── optimized_*.c/.h
+```
+
+The device-menu entry lives with the other menus in
+`applications/poom_app_pack/src/menu_picopass.c`.
+
+## Integration
+
+Registered by `applications/poom_picopass/CMakeLists.txt`, which requires:
+
+- `nfcal` - RFAL/ST25R3916 platform integration from `third-party/nfcal`
+- `poom_nfc` - NFC core bring-up (`poom_nfc_controller_start`)
+
+The menu is wired into the UI via `poom_app_pack` (`menu_picopass.c`) and
+`poom_menu` (the **PICOPASS** entry under **THE ZEN**). DES/3DES are vendored
+(`poom_des.c`) because ESP-IDF 6.1's mbedTLS dropped `MBEDTLS_DES_C`.
+
+> **License:** the `loclass/` files are GPL-3.0-or-later. Linking this app makes
+> the resulting firmware image GPL-3.0; the rest of `poom_picopass` is otherwise
+> self-contained (`poom_des.c` is Apache-2.0).
+
+## Public API
+
+- `PoomPicopassStatus poom_picopass_read(PoomPicopassDump* out, const uint8_t* key, bool elite)`
+  - reads a card into `out`; `key == NULL` uses the standard debit key,
+    `elite` selects elite key diversification
+- `int poom_picopass_format(const PoomPicopassDump* dump, char* buf, int buf_len)`
+  - renders a dump as human-readable hex lines
+- `const uint8_t poom_picopass_standard_key[8]`
+  - the well-known standard iCLASS debit key
+- `void menu_picopass_show(void)` (in `poom_app_pack`)
+  - opens the device-menu submenu
+
+## Runtime Flow
+
+```mermaid
+flowchart TD
+    A[poom_picopass_read] --> B[poom_nfc_controller_start]
+    B --> C[rfalPicoPassPollerInitialize<br/>PicoPass mode + field on]
+    C --> D[ACTALL / IDENTIFY: CSN]
+    D --> E[SELECT: real CSN]
+    E --> F[read config / e-purse / AIA]
+    F --> G[diversify key + READCHECK + reader MAC]
+    G --> H{CHECK}
+    H -->|ok| I[read AA1 blocks 6..app_limit]
+    H -->|fail| J[return pre-auth data]
+    I --> K[decode PACS: 3DES + strip sentinel]
+    K --> L[PoomPicopassDump]
+```

--- a/applications/poom_picopass/include/poom_picopass.h
+++ b/applications/poom_picopass/include/poom_picopass.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// High-level PicoPass (HID iCLASS) read flow for POOM.
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define POOM_PICOPASS_BLOCK_LEN      8
+#define POOM_PICOPASS_MAX_APP_BLOCKS 32  // enough for 2KS/16KS AA1 dumps
+
+// iCLASS block indices (AA1).
+#define POOM_PICOPASS_CSN_BLOCK      0
+#define POOM_PICOPASS_CONFIG_BLOCK   1
+#define POOM_PICOPASS_EPURSE_BLOCK   2
+#define POOM_PICOPASS_KD_BLOCK       3
+#define POOM_PICOPASS_KC_BLOCK       4
+#define POOM_PICOPASS_AIA_BLOCK      5
+#define POOM_PICOPASS_PACS_CFG_BLOCK 6
+
+typedef enum
+{
+    PoomPicopassOk = 0,
+    PoomPicopassErrNoCard,
+    PoomPicopassErrIdentify,
+    PoomPicopassErrSelect,
+    PoomPicopassErrReadCheck,
+    PoomPicopassErrAuth,
+    PoomPicopassErrRead,
+    PoomPicopassErrInit,
+} PoomPicopassStatus;
+
+typedef struct
+{
+    uint8_t csn[POOM_PICOPASS_BLOCK_LEN];     // real CSN (block 0)
+    uint8_t config[POOM_PICOPASS_BLOCK_LEN];  // block 1
+    uint8_t epurse[POOM_PICOPASS_BLOCK_LEN];  // block 2
+    uint8_t aia[POOM_PICOPASS_BLOCK_LEN];  // block 5 (application issuer area)
+    uint8_t div_key[POOM_PICOPASS_BLOCK_LEN];  // diversified key used for auth
+
+    bool authenticated;
+    uint8_t app_block_count;  // number of valid entries in blocks[]
+    uint8_t blocks[POOM_PICOPASS_MAX_APP_BLOCKS]
+                  [POOM_PICOPASS_BLOCK_LEN];  // AA1 from block 6
+
+    uint8_t app_limit;  // from config: last block of AA1
+
+    // HID PACS credential (from blocks 6-9), when present.
+    bool pacs_present;        // credential blocks were read
+    uint8_t pacs_encryption;  // block6[7]: 0x14 none, 0x15 DES, 0x17 3DES
+    uint8_t credential[POOM_PICOPASS_BLOCK_LEN];  // decrypted, sentinel removed
+    uint8_t bit_length;                           // Wiegand bit length
+} PoomPicopassDump;
+
+// Read a standard-keyed iCLASS card into `out`.
+// key: 8-byte iCLASS key. Pass NULL to use the well-known standard debit key.
+// elite: true if `key` is an elite key (needs diversified keygen).
+PoomPicopassStatus poom_picopass_read(PoomPicopassDump* out,
+                                      const uint8_t* key,
+                                      bool elite);
+
+// Format `dump` as human-readable hex lines into `buf` (returns bytes written).
+int poom_picopass_format(const PoomPicopassDump* dump, char* buf, int buf_len);
+
+// Well-known standard iCLASS debit key.
+extern const uint8_t poom_picopass_standard_key[POOM_PICOPASS_BLOCK_LEN];
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/poom_picopass/include/rfal_picopass.h
+++ b/applications/poom_picopass/include/rfal_picopass.h
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// PicoPass (HID iCLASS) low-level poller for POOM, built on ST's RFAL.
+//
+// iCLASS/PicoPass uses the ISO15693 physical layer but a proprietary
+// anticollision. The ST25R3916 supports it via RFAL_MODE_POLL_PICOPASS at
+// 26.48 kbit/s with a manual TX CRC.
+
+#pragma once
+
+#include <stdint.h>
+
+// RFAL provides ReturnCode + rfal* API. When building inside the_poom this
+// resolves to modules/nfc/include/rfal/rfal_rf.h. Kept as a single include
+// point so the dependency is obvious.
+#include "rfal_rf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RFAL_PICOPASS_UID_LEN       8
+#define RFAL_PICOPASS_MAX_BLOCK_LEN 8
+
+// ISO13239 CRC preset used by PicoPass.
+#define RFAL_PICOPASS_CRC_PRELOAD 0xE012
+
+// PicoPass commands (iCLASS). Note READ and IDENTIFY share opcode 0x0C; they
+// differ by argument length: IDENTIFY is bare 0x0C, READ is 0x0C + block + CRC.
+enum
+{
+    RFAL_PICOPASS_CMD_ACTALL       = 0x0A,
+    RFAL_PICOPASS_CMD_IDENTIFY     = 0x0C,
+    RFAL_PICOPASS_CMD_SELECT       = 0x81,
+    RFAL_PICOPASS_CMD_READCHECK_KD = 0x88,  // read-check with debit key (Kd)
+    RFAL_PICOPASS_CMD_READCHECK_KC = 0x18,  // read-check with credit key (Kc)
+    RFAL_PICOPASS_CMD_CHECK        = 0x05,
+    RFAL_PICOPASS_CMD_READ         = 0x0C,
+    RFAL_PICOPASS_CMD_READ4        = 0x06,
+    RFAL_PICOPASS_CMD_WRITE        = 0x87,
+};
+
+typedef struct
+{
+    uint8_t CSN[RFAL_PICOPASS_UID_LEN];  // anticollision CSN
+    uint8_t crc[2];
+} rfalPicoPassIdentifyRes;
+
+typedef struct
+{
+    uint8_t CSN[RFAL_PICOPASS_UID_LEN];  // real CSN
+    uint8_t crc[2];
+} rfalPicoPassSelectRes;
+
+typedef struct
+{
+    uint8_t CCNR[8];  // e-purse challenge, used as the MAC nonce
+} rfalPicoPassReadCheckRes;
+
+typedef struct
+{
+    uint8_t mac[4];
+} rfalPicoPassCheckRes;
+
+typedef struct
+{
+    uint8_t data[RFAL_PICOPASS_MAX_BLOCK_LEN];
+    uint8_t crc[2];
+} rfalPicoPassReadBlockRes;
+
+// Bring the ST25R3916 into PicoPass mode and turn the field on.
+ReturnCode rfalPicoPassPollerInitialize(void);
+
+// ACTALL wake-up. The card answers with just an SOF, so
+// RFAL_ERR_INCOMPLETE_BYTE (or a timeout) is the normal, expected result here.
+ReturnCode rfalPicoPassPollerCheckPresence(void);
+
+// Anticollision: read the CSN.
+ReturnCode rfalPicoPassPollerIdentify(rfalPicoPassIdentifyRes* idRes);
+
+// Select the card by CSN; returns the "real" CSN.
+ReturnCode rfalPicoPassPollerSelect(const uint8_t* csn,
+                                    rfalPicoPassSelectRes* selRes);
+
+// Read-check: fetch the e-purse (CCNR) that seeds the authentication MAC.
+// key_block_num is typically 2 (e-purse). use_credit selects Kc (0x18) vs Kd
+// (0x88).
+ReturnCode rfalPicoPassPollerReadCheck(rfalPicoPassReadCheckRes* rcRes,
+                                       uint8_t key_block_num,
+                                       int use_credit);
+
+// Authenticate: send the computed 4-byte MAC.
+ReturnCode rfalPicoPassPollerCheck(const uint8_t* mac,
+                                   rfalPicoPassCheckRes* chkRes);
+
+// Read one 8-byte block (CRC appended here).
+ReturnCode rfalPicoPassPollerReadBlock(uint8_t blockNum,
+                                       rfalPicoPassReadBlockRes* readRes);
+
+// Write one 8-byte block with its 4-byte MAC (no CRC; MAC is the integrity check).
+ReturnCode rfalPicoPassPollerWriteBlock(uint8_t blockNum,
+                                        const uint8_t data[8],
+                                        const uint8_t mac[4]);
+
+// ISO13239 CRC over `buf` with the PicoPass preset.
+uint16_t rfalPicoPassCrc16(const uint8_t* buf, uint16_t length);
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/poom_picopass/src/loclass/optimized_cipher.c
+++ b/applications/poom_picopass/src/loclass/optimized_cipher.c
@@ -1,0 +1,319 @@
+//-----------------------------------------------------------------------------
+// Borrowed initially from https://github.com/holiman/loclass
+// Copyright (C) 2014 Martin Holst Swende
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// WARNING
+//
+// THIS CODE IS CREATED FOR EXPERIMENTATION AND EDUCATIONAL USE ONLY.
+//
+// USAGE OF THIS CODE IN OTHER WAYS MAY INFRINGE UPON THE INTELLECTUAL
+// PROPERTY OF OTHER PARTIES, SUCH AS INSIDE SECURE AND HID GLOBAL,
+// AND MAY EXPOSE YOU TO AN INFRINGEMENT ACTION FROM THOSE PARTIES.
+//
+// THIS CODE SHOULD NEVER BE USED TO INFRINGE PATENTS OR INTELLECTUAL PROPERTY RIGHTS.
+//-----------------------------------------------------------------------------
+// It is a reconstruction of the cipher engine used in iClass, and RFID techology.
+//
+// The implementation is based on the work performed by
+// Flavio D. Garcia, Gerhard de Koning Gans, Roel Verdult and
+// Milosch Meriac in the paper "Dismantling IClass".
+//-----------------------------------------------------------------------------
+/*
+  This file contains an optimized version of the MAC-calculation algorithm. Some measurements on
+  a std laptop showed it runs in about 1/3 of the time:
+
+    Std: 0.428962
+    Opt: 0.151609
+
+  Additionally, it is self-reliant, not requiring e.g. bitstreams from the cipherutils, thus can
+  be easily dropped into a code base.
+
+  The optimizations have been performed in the following steps:
+  * Parameters passed by reference instead of by value.
+  * Iteration instead of recursion, un-nesting recursive loops into for-loops.
+  * Handling of bytes instead of individual bits, for less shuffling and masking
+  * Less creation of "objects", structs, and instead reuse of alloc:ed memory
+  * Inlining some functions via #define:s
+
+  As a consequence, this implementation is less generic. Also, I haven't bothered documenting this.
+  For a thorough documentation, check out the MAC-calculation within cipher.c instead.
+
+  -- MHS 2015
+**/
+
+/**
+
+  The runtime of opt_doTagMAC_2() with the MHS optimized version was 403 microseconds on Proxmark3.
+  This was still to slow for some newer readers which didn't want to wait that long.
+
+  Further optimizations to speedup the MAC calculations:
+  * Optimized opt_Tt logic
+  * Look up table for opt_select
+  * Removing many unnecessary bit maskings (& 0x1)
+  * updating state in place instead of alternating use of a second state structure
+  * remove the necessity to reverse bits of input and output bytes
+
+  opt_doTagMAC_2() now completes in 270 microseconds.
+
+  -- piwi 2019
+**/
+
+/**
+  add the possibility to do iCLASS on device only
+  -- iceman 2020
+**/
+
+#include "optimized_cipher.h"
+#include "optimized_elite.h"
+#include "optimized_ikeys.h"
+#include "optimized_cipherutils.h"
+
+static const uint8_t loclass_opt_select_LUT[256] = {
+    00, 03, 02, 01, 02, 03, 00, 01, 04, 07, 07, 04, 06, 07, 05, 04, 01, 02, 03, 00, 02, 03, 00, 01,
+    05, 06, 06, 05, 06, 07, 05, 04, 06, 05, 04, 07, 04, 05, 06, 07, 06, 05, 05, 06, 04, 05, 07, 06,
+    07, 04, 05, 06, 04, 05, 06, 07, 07, 04, 04, 07, 04, 05, 07, 06, 06, 05, 04, 07, 04, 05, 06, 07,
+    02, 01, 01, 02, 00, 01, 03, 02, 03, 00, 01, 02, 00, 01, 02, 03, 07, 04, 04, 07, 04, 05, 07, 06,
+    00, 03, 02, 01, 02, 03, 00, 01, 00, 03, 03, 00, 02, 03, 01, 00, 05, 06, 07, 04, 06, 07, 04, 05,
+    05, 06, 06, 05, 06, 07, 05, 04, 02, 01, 00, 03, 00, 01, 02, 03, 06, 05, 05, 06, 04, 05, 07, 06,
+    03, 00, 01, 02, 00, 01, 02, 03, 07, 04, 04, 07, 04, 05, 07, 06, 02, 01, 00, 03, 00, 01, 02, 03,
+    02, 01, 01, 02, 00, 01, 03, 02, 03, 00, 01, 02, 00, 01, 02, 03, 03, 00, 00, 03, 00, 01, 03, 02,
+    04, 07, 06, 05, 06, 07, 04, 05, 00, 03, 03, 00, 02, 03, 01, 00, 01, 02, 03, 00, 02, 03, 00, 01,
+    05, 06, 06, 05, 06, 07, 05, 04, 04, 07, 06, 05, 06, 07, 04, 05, 04, 07, 07, 04, 06, 07, 05, 04,
+    01, 02, 03, 00, 02, 03, 00, 01, 01, 02, 02, 01, 02, 03, 01, 00};
+
+/********************** the table above has been generated with this code: ********
+#include "util.h"
+static void init_opt_select_LUT(void) {
+    for (int r = 0; r < 256; r++) {
+        uint8_t r_ls2 = r << 2;
+        uint8_t r_and_ls2 = r & r_ls2;
+        uint8_t r_or_ls2  = r | r_ls2;
+        uint8_t z0 = (r_and_ls2 >> 5) ^ ((r & ~r_ls2) >> 4) ^ ( r_or_ls2 >> 3);
+        uint8_t z1 = (r_or_ls2 >> 6) ^ ( r_or_ls2 >> 1) ^ (r >> 5) ^ r;
+        uint8_t z2 = ((r & ~r_ls2) >> 4) ^ (r_and_ls2 >> 3) ^ r;
+        loclass_opt_select_LUT[r] = (z0 & 4) | (z1 & 2) | (z2 & 1);
+    }
+    print_result("", loclass_opt_select_LUT, 256);
+}
+***********************************************************************************/
+
+static inline void loclass_opt_successor(const uint8_t* k, LoclassState_t* s, uint8_t y) {
+    uint16_t Tt = s->t & 0xc533;
+    Tt = Tt ^ (Tt >> 1);
+    Tt = Tt ^ (Tt >> 4);
+    Tt = Tt ^ (Tt >> 10);
+    Tt = Tt ^ (Tt >> 8);
+
+    s->t = (s->t >> 1);
+    s->t |= (Tt ^ (s->r >> 7) ^ (s->r >> 3)) << 15;
+
+    uint8_t opt_B = s->b;
+    opt_B ^= s->b >> 6;
+    opt_B ^= s->b >> 5;
+    opt_B ^= s->b >> 4;
+
+    s->b = s->b >> 1;
+    s->b |= (opt_B ^ s->r) << 7;
+
+    uint8_t Tt1 = Tt & 0x01;
+    uint8_t opt_select = loclass_opt_select_LUT[s->r] ^ Tt1 ^ ((Tt1 ^ (y & 0x01)) << 1);
+
+    uint8_t r = s->r;
+    s->r = (k[opt_select] ^ s->b) + s->l;
+    s->l = s->r + r;
+}
+
+static inline void loclass_opt_suc(
+    const uint8_t* k,
+    LoclassState_t* s,
+    const uint8_t* in,
+    uint8_t length,
+    bool add32Zeroes) {
+    for(int i = 0; i < length; i++) {
+        uint8_t head = in[i];
+#pragma GCC unroll 8
+        for(int j = 0; j < 8; j++) {
+            loclass_opt_successor(k, s, head);
+            head >>= 1;
+        }
+    }
+    // For tag MAC, an additional 32 zeroes
+    if(add32Zeroes) {
+        for(int i = 0; i < 32; i++) {
+            loclass_opt_successor(k, s, 0);
+        }
+    }
+}
+
+static inline void loclass_opt_output(const uint8_t* k, LoclassState_t* s, uint8_t* buffer) {
+#pragma GCC unroll 4
+    for(uint8_t times = 0; times < 4; times++) {
+        uint8_t bout = 0;
+        bout |= (s->r & 0x4) >> 2;
+        loclass_opt_successor(k, s, 0);
+        bout |= (s->r & 0x4) >> 1;
+        loclass_opt_successor(k, s, 0);
+        bout |= (s->r & 0x4);
+        loclass_opt_successor(k, s, 0);
+        bout |= (s->r & 0x4) << 1;
+        loclass_opt_successor(k, s, 0);
+        bout |= (s->r & 0x4) << 2;
+        loclass_opt_successor(k, s, 0);
+        bout |= (s->r & 0x4) << 3;
+        loclass_opt_successor(k, s, 0);
+        bout |= (s->r & 0x4) << 4;
+        loclass_opt_successor(k, s, 0);
+        bout |= (s->r & 0x4) << 5;
+        loclass_opt_successor(k, s, 0);
+        buffer[times] = bout;
+    }
+}
+
+static void loclass_opt_MAC(uint8_t* k, uint8_t* input, uint8_t* out) {
+    LoclassState_t _init = {
+        ((k[0] ^ 0x4c) + 0xEC) & 0xFF, // l
+        ((k[0] ^ 0x4c) + 0x21) & 0xFF, // r
+        0x4c, // b
+        0xE012 // t
+    };
+
+    loclass_opt_suc(k, &_init, input, 12, false);
+    loclass_opt_output(k, &_init, out);
+}
+
+static void loclass_opt_MAC_N(uint8_t* k, uint8_t* input, uint8_t in_size, uint8_t* out) {
+    LoclassState_t _init = {
+        ((k[0] ^ 0x4c) + 0xEC) & 0xFF, // l
+        ((k[0] ^ 0x4c) + 0x21) & 0xFF, // r
+        0x4c, // b
+        0xE012 // t
+    };
+
+    loclass_opt_suc(k, &_init, input, in_size, false);
+    loclass_opt_output(k, &_init, out);
+}
+
+void loclass_opt_doReaderMAC(uint8_t* cc_nr_p, uint8_t* div_key_p, uint8_t mac[4]) {
+    uint8_t dest[] = {0, 0, 0, 0, 0, 0, 0, 0};
+    loclass_opt_MAC(div_key_p, cc_nr_p, dest);
+    memcpy(mac, dest, 4);
+}
+
+void loclass_opt_doReaderMAC_2(
+    LoclassState_t _init,
+    const uint8_t* nr,
+    uint8_t mac[4],
+    const uint8_t* div_key_p) {
+    loclass_opt_suc(div_key_p, &_init, nr, 4, false);
+    loclass_opt_output(div_key_p, &_init, mac);
+}
+
+void loclass_doMAC_N(uint8_t* in_p, uint8_t in_size, uint8_t* div_key_p, uint8_t mac[4]) {
+    uint8_t dest[] = {0, 0, 0, 0, 0, 0, 0, 0};
+    loclass_opt_MAC_N(div_key_p, in_p, in_size, dest);
+    memcpy(mac, dest, 4);
+}
+
+void loclass_opt_doTagMAC(uint8_t* cc_p, const uint8_t* div_key_p, uint8_t mac[4]) {
+    LoclassState_t _init = {
+        ((div_key_p[0] ^ 0x4c) + 0xEC) & 0xFF, // l
+        ((div_key_p[0] ^ 0x4c) + 0x21) & 0xFF, // r
+        0x4c, // b
+        0xE012 // t
+    };
+    loclass_opt_suc(div_key_p, &_init, cc_p, 12, true);
+    loclass_opt_output(div_key_p, &_init, mac);
+}
+
+/**
+ * The tag MAC can be divided (both can, but no point in dividing the reader mac) into
+ * two functions, since the first 8 bytes are known, we can pre-calculate the state
+ * reached after feeding CC to the cipher.
+ * @param cc_p
+ * @param div_key_p
+ * @return the cipher state
+ */
+LoclassState_t loclass_opt_doTagMAC_1(uint8_t* cc_p, const uint8_t* div_key_p) {
+    LoclassState_t _init = {
+        ((div_key_p[0] ^ 0x4c) + 0xEC) & 0xFF, // l
+        ((div_key_p[0] ^ 0x4c) + 0x21) & 0xFF, // r
+        0x4c, // b
+        0xE012 // t
+    };
+    loclass_opt_suc(div_key_p, &_init, cc_p, 8, false);
+    return _init;
+}
+
+/**
+ * The second part of the tag MAC calculation, since the CC is already calculated into the state,
+ * this function is fed only the NR, and internally feeds the remaining 32 0-bits to generate the tag
+ * MAC response.
+ * @param _init - precalculated cipher state
+ * @param nr - the reader challenge
+ * @param mac - where to store the MAC
+ * @param div_key_p - the key to use
+ */
+void loclass_opt_doTagMAC_2(
+    LoclassState_t _init,
+    const uint8_t* nr,
+    uint8_t mac[4],
+    const uint8_t* div_key_p) {
+    loclass_opt_suc(div_key_p, &_init, nr, 4, true);
+    loclass_opt_output(div_key_p, &_init, mac);
+}
+
+/**
+ * The second part of the tag MAC calculation, since the CC is already calculated into the state,
+ * this function is fed only the NR, and generates both the reader and tag MACs.
+ * @param _init - precalculated cipher state
+ * @param nr - the reader challenge
+ * @param rmac - where to store the reader MAC
+ * @param tmac - where to store the tag MAC
+ * @param div_key_p - the key to use
+ */
+void loclass_opt_doBothMAC_2(
+    LoclassState_t _init,
+    const uint8_t* nr,
+    uint8_t rmac[4],
+    uint8_t tmac[4],
+    const uint8_t* div_key_p) {
+    LoclassState_t* s = &_init;
+    loclass_opt_suc(div_key_p, s, nr, 4, false);
+    loclass_opt_output(div_key_p, s, rmac);
+    loclass_opt_output(div_key_p, s, tmac);
+}
+
+void loclass_iclass_calc_div_key(
+    const uint8_t* csn,
+    const uint8_t* key,
+    uint8_t* div_key,
+    bool elite) {
+    if(elite) {
+        uint8_t keytable[128] = {0};
+        uint8_t key_index[8] = {0};
+        uint8_t key_sel[8] = {0};
+        uint8_t key_sel_p[8] = {0};
+        loclass_hash2(key, keytable);
+        loclass_hash1(csn, key_index);
+        for(uint8_t i = 0; i < 8; i++) key_sel[i] = keytable[key_index[i]];
+
+        //Permute from iclass format to standard format
+        loclass_permutekey_rev(key_sel, key_sel_p);
+        loclass_diversifyKey(csn, key_sel_p, div_key);
+    } else {
+        loclass_diversifyKey(csn, key, div_key);
+    }
+}

--- a/applications/poom_picopass/src/loclass/optimized_cipher.h
+++ b/applications/poom_picopass/src/loclass/optimized_cipher.h
@@ -1,0 +1,117 @@
+//-----------------------------------------------------------------------------
+// Borrowed initially from https://github.com/holiman/loclass
+// More recently from https://github.com/RfidResearchGroup/proxmark3
+// Copyright (C) 2014 Martin Holst Swende
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// WARNING
+//
+// THIS CODE IS CREATED FOR EXPERIMENTATION AND EDUCATIONAL USE ONLY.
+//
+// USAGE OF THIS CODE IN OTHER WAYS MAY INFRINGE UPON THE INTELLECTUAL
+// PROPERTY OF OTHER PARTIES, SUCH AS INSIDE SECURE AND HID GLOBAL,
+// AND MAY EXPOSE YOU TO AN INFRINGEMENT ACTION FROM THOSE PARTIES.
+//
+// THIS CODE SHOULD NEVER BE USED TO INFRINGE PATENTS OR INTELLECTUAL PROPERTY RIGHTS.
+//-----------------------------------------------------------------------------
+// It is a reconstruction of the cipher engine used in iClass, and RFID techology.
+//
+// The implementation is based on the work performed by
+// Flavio D. Garcia, Gerhard de Koning Gans, Roel Verdult and
+// Milosch Meriac in the paper "Dismantling IClass".
+//-----------------------------------------------------------------------------
+#ifndef OPTIMIZED_CIPHER_H
+#define OPTIMIZED_CIPHER_H
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+* Definition 1 (Cipher state). A cipher state of iClass s is an element of F 40/2
+* consisting of the following four components:
+*   1. the left register l = (l 0 . . . l 7 ) ∈ F 8/2 ;
+*   2. the right register r = (r 0 . . . r 7 ) ∈ F 8/2 ;
+*   3. the top register t = (t 0 . . . t 15 ) ∈ F 16/2 .
+*   4. the bottom register b = (b 0 . . . b 7 ) ∈ F 8/2 .
+**/
+typedef struct {
+    uint8_t l;
+    uint8_t r;
+    uint8_t b;
+    uint16_t t;
+} LoclassState_t;
+
+/** The reader MAC is MAC(key, CC * NR )
+ **/
+void loclass_opt_doReaderMAC(uint8_t* cc_nr_p, uint8_t* div_key_p, uint8_t mac[4]);
+
+void loclass_opt_doReaderMAC_2(
+    LoclassState_t _init,
+    const uint8_t* nr,
+    uint8_t mac[4],
+    const uint8_t* div_key_p);
+
+/**
+ * The tag MAC is MAC(key, CC * NR * 32x0))
+ */
+void loclass_opt_doTagMAC(uint8_t* cc_p, const uint8_t* div_key_p, uint8_t mac[4]);
+
+/**
+ * The tag MAC can be divided (both can, but no point in dividing the reader mac) into
+ * two functions, since the first 8 bytes are known, we can pre-calculate the state
+ * reached after feeding CC to the cipher.
+ * @param cc_p
+ * @param div_key_p
+ * @return the cipher state
+ */
+LoclassState_t loclass_opt_doTagMAC_1(uint8_t* cc_p, const uint8_t* div_key_p);
+/**
+ * The second part of the tag MAC calculation, since the CC is already calculated into the state,
+ * this function is fed only the NR, and internally feeds the remaining 32 0-bits to generate the tag
+ * MAC response.
+ * @param _init - precalculated cipher state
+ * @param nr - the reader challenge
+ * @param mac - where to store the MAC
+ * @param div_key_p - the key to use
+ */
+void loclass_opt_doTagMAC_2(
+    LoclassState_t _init,
+    const uint8_t* nr,
+    uint8_t mac[4],
+    const uint8_t* div_key_p);
+
+/**
+ * The same as loclass_opt_doTagMAC_2, but calculates both the reader and tag MACs at the same time
+ * @param _init - precalculated cipher state
+ * @param nr - the reader challenge
+ * @param rmac - where to store the reader MAC
+ * @param tmac - where to store the tag MAC
+ * @param div_key_p - the key to use
+ */
+void loclass_opt_doBothMAC_2(
+    LoclassState_t _init,
+    const uint8_t* nr,
+    uint8_t rmac[4],
+    uint8_t tmac[4],
+    const uint8_t* div_key_p);
+
+void loclass_doMAC_N(uint8_t* in_p, uint8_t in_size, uint8_t* div_key_p, uint8_t mac[4]);
+void loclass_iclass_calc_div_key(
+    const uint8_t* csn,
+    const uint8_t* key,
+    uint8_t* div_key,
+    bool elite);
+#endif // OPTIMIZED_CIPHER_H

--- a/applications/poom_picopass/src/loclass/optimized_cipherutils.c
+++ b/applications/poom_picopass/src/loclass/optimized_cipherutils.c
@@ -1,0 +1,136 @@
+//-----------------------------------------------------------------------------
+// Borrowed initially from https://github.com/holiman/loclass
+// Copyright (C) 2014 Martin Holst Swende
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// WARNING
+//
+// THIS CODE IS CREATED FOR EXPERIMENTATION AND EDUCATIONAL USE ONLY.
+//
+// USAGE OF THIS CODE IN OTHER WAYS MAY INFRINGE UPON THE INTELLECTUAL
+// PROPERTY OF OTHER PARTIES, SUCH AS INSIDE SECURE AND HID GLOBAL,
+// AND MAY EXPOSE YOU TO AN INFRINGEMENT ACTION FROM THOSE PARTIES.
+//
+// THIS CODE SHOULD NEVER BE USED TO INFRINGE PATENTS OR INTELLECTUAL PROPERTY RIGHTS.
+//-----------------------------------------------------------------------------
+// It is a reconstruction of the cipher engine used in iClass, and RFID techology.
+//
+// The implementation is based on the work performed by
+// Flavio D. Garcia, Gerhard de Koning Gans, Roel Verdult and
+// Milosch Meriac in the paper "Dismantling IClass".
+//-----------------------------------------------------------------------------
+#include "optimized_cipherutils.h"
+#include <stdint.h>
+
+/**
+ *
+ * @brief Return and remove the first bit (x0) in the stream : <x0 x1 x2 x3 ... xn >
+ * @param stream
+ * @return
+ */
+bool loclass_headBit(LoclassBitstreamIn_t* stream) {
+    int bytepos = stream->position >> 3; // divide by 8
+    int bitpos = (stream->position++) & 7; // mask out 00000111
+    return (*(stream->buffer + bytepos) >> (7 - bitpos)) & 1;
+}
+/**
+ * @brief Return and remove the last bit (xn) in the stream: <x0 x1 x2 ... xn>
+ * @param stream
+ * @return
+ */
+bool loclass_tailBit(LoclassBitstreamIn_t* stream) {
+    int bitpos = stream->numbits - 1 - (stream->position++);
+
+    int bytepos = bitpos >> 3;
+    bitpos &= 7;
+    return (*(stream->buffer + bytepos) >> (7 - bitpos)) & 1;
+}
+/**
+ * @brief Pushes bit onto the stream
+ * @param stream
+ * @param bit
+ */
+void loclass_pushBit(LoclassBitstreamOut_t* stream, bool bit) {
+    int bytepos = stream->position >> 3; // divide by 8
+    int bitpos = stream->position & 7;
+    *(stream->buffer + bytepos) |= (bit) << (7 - bitpos);
+    stream->position++;
+    stream->numbits++;
+}
+
+/**
+ * @brief Pushes the lower six bits onto the stream
+ * as b0 b1 b2 b3 b4 b5 b6
+ * @param stream
+ * @param bits
+ */
+void loclass_push6bits(LoclassBitstreamOut_t* stream, uint8_t bits) {
+    loclass_pushBit(stream, bits & 0x20);
+    loclass_pushBit(stream, bits & 0x10);
+    loclass_pushBit(stream, bits & 0x08);
+    loclass_pushBit(stream, bits & 0x04);
+    loclass_pushBit(stream, bits & 0x02);
+    loclass_pushBit(stream, bits & 0x01);
+}
+
+/**
+ * @brief loclass_bitsLeft
+ * @param stream
+ * @return number of bits left in stream
+ */
+int loclass_bitsLeft(LoclassBitstreamIn_t* stream) {
+    return stream->numbits - stream->position;
+}
+/**
+ * @brief numBits
+ * @param stream
+ * @return Number of bits stored in stream
+ */
+void loclass_x_num_to_bytes(uint64_t n, size_t len, uint8_t* dest) {
+    while(len--) {
+        dest[len] = (uint8_t)n;
+        n >>= 8;
+    }
+}
+
+uint64_t loclass_x_bytes_to_num(uint8_t* src, size_t len) {
+    uint64_t num = 0;
+    while(len--) {
+        num = (num << 8) | (*src);
+        src++;
+    }
+    return num;
+}
+
+uint8_t loclass_reversebytes(uint8_t b) {
+    b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
+    b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
+    b = (b & 0xAA) >> 1 | (b & 0x55) << 1;
+    return b;
+}
+
+void loclass_reverse_arraybytes(uint8_t* arr, size_t len) {
+    uint8_t i;
+    for(i = 0; i < len; i++) {
+        arr[i] = loclass_reversebytes(arr[i]);
+    }
+}
+
+void loclass_reverse_arraycopy(uint8_t* arr, uint8_t* dest, size_t len) {
+    uint8_t i;
+    for(i = 0; i < len; i++) {
+        dest[i] = loclass_reversebytes(arr[i]);
+    }
+}

--- a/applications/poom_picopass/src/loclass/optimized_cipherutils.h
+++ b/applications/poom_picopass/src/loclass/optimized_cipherutils.h
@@ -1,0 +1,64 @@
+//-----------------------------------------------------------------------------
+// Borrowed initially from https://github.com/holiman/loclass
+// More recently from https://github.com/RfidResearchGroup/proxmark3
+// Copyright (C) 2014 Martin Holst Swende
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// WARNING
+//
+// THIS CODE IS CREATED FOR EXPERIMENTATION AND EDUCATIONAL USE ONLY.
+//
+// USAGE OF THIS CODE IN OTHER WAYS MAY INFRINGE UPON THE INTELLECTUAL
+// PROPERTY OF OTHER PARTIES, SUCH AS INSIDE SECURE AND HID GLOBAL,
+// AND MAY EXPOSE YOU TO AN INFRINGEMENT ACTION FROM THOSE PARTIES.
+//
+// THIS CODE SHOULD NEVER BE USED TO INFRINGE PATENTS OR INTELLECTUAL PROPERTY RIGHTS.
+//-----------------------------------------------------------------------------
+// It is a reconstruction of the cipher engine used in iClass, and RFID techology.
+//
+// The implementation is based on the work performed by
+// Flavio D. Garcia, Gerhard de Koning Gans, Roel Verdult and
+// Milosch Meriac in the paper "Dismantling IClass".
+//-----------------------------------------------------------------------------
+#ifndef CIPHERUTILS_H
+#define CIPHERUTILS_H
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+typedef struct {
+    uint8_t* buffer;
+    uint8_t numbits;
+    uint8_t position;
+} LoclassBitstreamIn_t;
+
+typedef struct {
+    uint8_t* buffer;
+    uint8_t numbits;
+    uint8_t position;
+} LoclassBitstreamOut_t;
+
+bool loclass_headBit(LoclassBitstreamIn_t* stream);
+bool loclass_tailBit(LoclassBitstreamIn_t* stream);
+void loclass_pushBit(LoclassBitstreamOut_t* stream, bool bit);
+int loclass_bitsLeft(LoclassBitstreamIn_t* stream);
+
+void loclass_push6bits(LoclassBitstreamOut_t* stream, uint8_t bits);
+void loclass_x_num_to_bytes(uint64_t n, size_t len, uint8_t* dest);
+uint64_t loclass_x_bytes_to_num(uint8_t* src, size_t len);
+uint8_t loclass_reversebytes(uint8_t b);
+void loclass_reverse_arraybytes(uint8_t* arr, size_t len);
+void loclass_reverse_arraycopy(uint8_t* arr, uint8_t* dest, size_t len);
+#endif // CIPHERUTILS_H

--- a/applications/poom_picopass/src/loclass/optimized_elite.c
+++ b/applications/poom_picopass/src/loclass/optimized_elite.c
@@ -1,0 +1,232 @@
+//-----------------------------------------------------------------------------
+// Borrowed initially from https://github.com/holiman/loclass
+// Copyright (C) 2014 Martin Holst Swende
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// WARNING
+//
+// THIS CODE IS CREATED FOR EXPERIMENTATION AND EDUCATIONAL USE ONLY.
+//
+// USAGE OF THIS CODE IN OTHER WAYS MAY INFRINGE UPON THE INTELLECTUAL
+// PROPERTY OF OTHER PARTIES, SUCH AS INSIDE SECURE AND HID GLOBAL,
+// AND MAY EXPOSE YOU TO AN INFRINGEMENT ACTION FROM THOSE PARTIES.
+//
+// THIS CODE SHOULD NEVER BE USED TO INFRINGE PATENTS OR INTELLECTUAL PROPERTY RIGHTS.
+//-----------------------------------------------------------------------------
+// It is a reconstruction of the cipher engine used in iClass, and RFID techology.
+//
+// The implementation is based on the work performed by
+// Flavio D. Garcia, Gerhard de Koning Gans, Roel Verdult and
+// Milosch Meriac in the paper "Dismantling IClass".
+//-----------------------------------------------------------------------------
+#include "optimized_elite.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include "poom_des.h"
+#include "optimized_ikeys.h"
+
+/**
+ * @brief Permutes a key from standard NIST format to Iclass specific format
+ *  from http://www.proxmark.org/forum/viewtopic.php?pid=11220#p11220
+ *
+ *  If you loclass_permute [6c 8d 44 f9 2a 2d 01 bf]  you get  [8a 0d b9 88 bb a7 90 ea]  as shown below.
+ *
+ *  1 0 1 1 1 1 1 1  bf
+ *  0 0 0 0 0 0 0 1  01
+ *  0 0 1 0 1 1 0 1  2d
+ *  0 0 1 0 1 0 1 0  2a
+ *  1 1 1 1 1 0 0 1  f9
+ *  0 1 0 0 0 1 0 0  44
+ *  1 0 0 0 1 1 0 1  8d
+ *  0 1 1 0 1 1 0 0  6c
+ *
+ *  8 0 b 8 b a 9 e
+ *  a d 9 8 b 7 0 a
+ *
+ * @param key
+ * @param dest
+ */
+void loclass_permutekey(const uint8_t key[8], uint8_t dest[8]) {
+    int i;
+    for(i = 0; i < 8; i++) {
+        dest[i] = (((key[7] & (0x80 >> i)) >> (7 - i)) << 7) |
+                  (((key[6] & (0x80 >> i)) >> (7 - i)) << 6) |
+                  (((key[5] & (0x80 >> i)) >> (7 - i)) << 5) |
+                  (((key[4] & (0x80 >> i)) >> (7 - i)) << 4) |
+                  (((key[3] & (0x80 >> i)) >> (7 - i)) << 3) |
+                  (((key[2] & (0x80 >> i)) >> (7 - i)) << 2) |
+                  (((key[1] & (0x80 >> i)) >> (7 - i)) << 1) |
+                  (((key[0] & (0x80 >> i)) >> (7 - i)) << 0);
+    }
+}
+/**
+ * Permutes  a key from iclass specific format to NIST format
+ * @brief loclass_permutekey_rev
+ * @param key
+ * @param dest
+ */
+void loclass_permutekey_rev(const uint8_t key[8], uint8_t dest[8]) {
+    int i;
+    for(i = 0; i < 8; i++) {
+        dest[7 - i] = (((key[0] & (0x80 >> i)) >> (7 - i)) << 7) |
+                      (((key[1] & (0x80 >> i)) >> (7 - i)) << 6) |
+                      (((key[2] & (0x80 >> i)) >> (7 - i)) << 5) |
+                      (((key[3] & (0x80 >> i)) >> (7 - i)) << 4) |
+                      (((key[4] & (0x80 >> i)) >> (7 - i)) << 3) |
+                      (((key[5] & (0x80 >> i)) >> (7 - i)) << 2) |
+                      (((key[6] & (0x80 >> i)) >> (7 - i)) << 1) |
+                      (((key[7] & (0x80 >> i)) >> (7 - i)) << 0);
+    }
+}
+
+/**
+ * Helper function for loclass_hash1
+ * @brief loclass_rr
+ * @param val
+ * @return
+ */
+static uint8_t loclass_rr(uint8_t val) {
+    return val >> 1 | ((val & 1) << 7);
+}
+
+/**
+ * Helper function for loclass_hash1
+ * @brief rl
+ * @param val
+ * @return
+ */
+static uint8_t loclass_rl(uint8_t val) {
+    return val << 1 | ((val & 0x80) >> 7);
+}
+
+/**
+ * Helper function for loclass_hash1
+ * @brief loclass_swap
+ * @param val
+ * @return
+ */
+static uint8_t loclass_swap(uint8_t val) {
+    return ((val >> 4) & 0xFF) | ((val & 0xFF) << 4);
+}
+
+/**
+ * Hash1 takes CSN as input, and determines what bytes in the keytable will be used
+ * when constructing the K_sel.
+ * @param csn the CSN used
+ * @param k output
+ */
+void loclass_hash1(const uint8_t csn[], uint8_t k[]) {
+    k[0] = csn[0] ^ csn[1] ^ csn[2] ^ csn[3] ^ csn[4] ^ csn[5] ^ csn[6] ^ csn[7];
+    k[1] = csn[0] + csn[1] + csn[2] + csn[3] + csn[4] + csn[5] + csn[6] + csn[7];
+    k[2] = loclass_rr(loclass_swap(csn[2] + k[1]));
+    k[3] = loclass_rl(loclass_swap(csn[3] + k[0]));
+    k[4] = ~loclass_rr(csn[4] + k[2]) + 1;
+    k[5] = ~loclass_rl(csn[5] + k[3]) + 1;
+    k[6] = loclass_rr(csn[6] + (k[4] ^ 0x3c));
+    k[7] = loclass_rl(csn[7] + (k[5] ^ 0xc3));
+
+    k[7] &= 0x7F;
+    k[6] &= 0x7F;
+    k[5] &= 0x7F;
+    k[4] &= 0x7F;
+    k[3] &= 0x7F;
+    k[2] &= 0x7F;
+    k[1] &= 0x7F;
+    k[0] &= 0x7F;
+}
+/**
+Definition 14. Define the rotate key function loclass_rk : (F 82 ) 8 × N → (F 82 ) 8 as
+loclass_rk(x [0] . . . x [7] , 0) = x [0] . . . x [7]
+loclass_rk(x [0] . . . x [7] , n + 1) = loclass_rk(loclass_rl(x [0] ) . . . loclass_rl(x [7] ), n)
+**/
+static void loclass_rk(const uint8_t* key, uint8_t n, uint8_t* outp_key) {
+    memcpy(outp_key, key, 8);
+    uint8_t j;
+    while(n-- > 0) {
+        for(j = 0; j < 8; j++) outp_key[j] = loclass_rl(outp_key[j]);
+    }
+    return;
+}
+
+static mbedtls_des_context loclass_ctx_enc;
+static mbedtls_des_context loclass_ctx_dec;
+
+static void loclass_desdecrypt_iclass(uint8_t* iclass_key, uint8_t* input, uint8_t* output) {
+    uint8_t key_std_format[8] = {0};
+    loclass_permutekey_rev(iclass_key, key_std_format);
+    mbedtls_des_setkey_dec(&loclass_ctx_dec, key_std_format);
+    mbedtls_des_crypt_ecb(&loclass_ctx_dec, input, output);
+}
+
+static void loclass_desencrypt_iclass(const uint8_t* iclass_key, uint8_t* input, uint8_t* output) {
+    uint8_t key_std_format[8] = {0};
+    loclass_permutekey_rev(iclass_key, key_std_format);
+    mbedtls_des_setkey_enc(&loclass_ctx_enc, key_std_format);
+    mbedtls_des_crypt_ecb(&loclass_ctx_enc, input, output);
+}
+
+/**
+ * @brief Insert uint8_t[8] custom master key to calculate hash2 and return key_select.
+ * @param key unpermuted custom key
+ * @param loclass_hash1 loclass_hash1
+ * @param key_sel output key_sel=h[loclass_hash1[i]]
+ */
+void loclass_hash2(const uint8_t* key64, uint8_t* outp_keytable) {
+    /**
+     *Expected:
+     * High Security Key Table
+
+    00  F1 35 59 A1 0D 5A 26 7F 18 60 0B 96 8A C0 25 C1
+    10  BF A1 3B B0 FF 85 28 75 F2 1F C6 8F 0E 74 8F 21
+    20  14 7A 55 16 C8 A9 7D B3 13 0C 5D C9 31 8D A9 B2
+    30  A3 56 83 0F 55 7E DE 45 71 21 D2 6D C1 57 1C 9C
+    40  78 2F 64 51 42 7B 64 30 FA 26 51 76 D3 E0 FB B6
+    50  31 9F BF 2F 7E 4F 94 B4 BD 4F 75 91 E3 1B EB 42
+    60  3F 88 6F B8 6C 2C 93 0D 69 2C D5 20 3C C1 61 95
+    70  43 08 A0 2F FE B3 26 D7 98 0B 34 7B 47 70 A0 AB
+
+    **** The 64-bit HS Custom Key Value = 5B7C62C491C11B39 ******/
+    uint8_t key64_negated[8] = {0};
+    uint8_t z[8][8] = {{0}, {0}};
+    uint8_t temp_output[8] = {0};
+
+    //calculate complement of key
+    int i;
+    for(i = 0; i < 8; i++) key64_negated[i] = ~key64[i];
+
+    // Once again, key is on iclass-format
+    loclass_desencrypt_iclass(key64, key64_negated, z[0]);
+
+    uint8_t y[8][8] = {{0}, {0}};
+
+    // y[0]=DES_dec(z[0],~key)
+    // Once again, key is on iclass-format
+    loclass_desdecrypt_iclass(z[0], key64_negated, y[0]);
+
+    for(i = 1; i < 8; i++) {
+        loclass_rk(key64, i, temp_output);
+        loclass_desdecrypt_iclass(temp_output, z[i - 1], z[i]);
+        loclass_desencrypt_iclass(temp_output, y[i - 1], y[i]);
+    }
+
+    if(outp_keytable != NULL) {
+        for(i = 0; i < 8; i++) {
+            memcpy(outp_keytable + i * 16, y[i], 8);
+            memcpy(outp_keytable + 8 + i * 16, z[i], 8);
+        }
+    }
+}

--- a/applications/poom_picopass/src/loclass/optimized_elite.h
+++ b/applications/poom_picopass/src/loclass/optimized_elite.h
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------------
+// Borrowed initially from https://github.com/holiman/loclass
+// More recently from https://github.com/RfidResearchGroup/proxmark3
+// Copyright (C) 2014 Martin Holst Swende
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// WARNING
+//
+// THIS CODE IS CREATED FOR EXPERIMENTATION AND EDUCATIONAL USE ONLY.
+//
+// USAGE OF THIS CODE IN OTHER WAYS MAY INFRINGE UPON THE INTELLECTUAL
+// PROPERTY OF OTHER PARTIES, SUCH AS INSIDE SECURE AND HID GLOBAL,
+// AND MAY EXPOSE YOU TO AN INFRINGEMENT ACTION FROM THOSE PARTIES.
+//
+// THIS CODE SHOULD NEVER BE USED TO INFRINGE PATENTS OR INTELLECTUAL PROPERTY RIGHTS.
+//-----------------------------------------------------------------------------
+// It is a reconstruction of the cipher engine used in iClass, and RFID techology.
+//
+// The implementation is based on the work performed by
+// Flavio D. Garcia, Gerhard de Koning Gans, Roel Verdult and
+// Milosch Meriac in the paper "Dismantling IClass".
+//-----------------------------------------------------------------------------
+#ifndef ELITE_CRACK_H
+#define ELITE_CRACK_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+void loclass_permutekey(const uint8_t key[8], uint8_t dest[8]);
+/**
+ * Permutes  a key from iclass specific format to NIST format
+ * @brief loclass_permutekey_rev
+ * @param key
+ * @param dest
+ */
+void loclass_permutekey_rev(const uint8_t key[8], uint8_t dest[8]);
+/**
+ * Hash1 takes CSN as input, and determines what bytes in the keytable will be used
+ * when constructing the K_sel.
+ * @param csn the CSN used
+ * @param k output
+ */
+void loclass_hash1(const uint8_t* csn, uint8_t* k);
+void loclass_hash2(const uint8_t* key64, uint8_t* outp_keytable);
+
+#endif

--- a/applications/poom_picopass/src/loclass/optimized_ikeys.c
+++ b/applications/poom_picopass/src/loclass/optimized_ikeys.c
@@ -1,0 +1,320 @@
+//-----------------------------------------------------------------------------
+// Borrowed initially from https://github.com/holiman/loclass
+// Copyright (C) 2014 Martin Holst Swende
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// WARNING
+//
+// THIS CODE IS CREATED FOR EXPERIMENTATION AND EDUCATIONAL USE ONLY.
+//
+// USAGE OF THIS CODE IN OTHER WAYS MAY INFRINGE UPON THE INTELLECTUAL
+// PROPERTY OF OTHER PARTIES, SUCH AS INSIDE SECURE AND HID GLOBAL,
+// AND MAY EXPOSE YOU TO AN INFRINGEMENT ACTION FROM THOSE PARTIES.
+//
+// THIS CODE SHOULD NEVER BE USED TO INFRINGE PATENTS OR INTELLECTUAL PROPERTY RIGHTS.
+//-----------------------------------------------------------------------------
+// It is a reconstruction of the cipher engine used in iClass, and RFID techology.
+//
+// The implementation is based on the work performed by
+// Flavio D. Garcia, Gerhard de Koning Gans, Roel Verdult and
+// Milosch Meriac in the paper "Dismantling IClass".
+//-----------------------------------------------------------------------------
+
+/**
+From "Dismantling iclass":
+    This section describes in detail the built-in key diversification algorithm of iClass.
+    Besides the obvious purpose of deriving a card key from a master key, this
+    algorithm intends to circumvent weaknesses in the cipher by preventing the
+    usage of certain ‘weak’ keys. In order to compute a diversified key, the iClass
+    reader first encrypts the card identity id with the master key K, using single
+    DES. The resulting ciphertext is then input to a function called loclass_hash0 which
+    outputs the diversified key k.
+
+    k = loclass_hash0(DES enc (id, K))
+
+    Here the DES encryption of id with master key K outputs a cryptogram c
+    of 64 bits. These 64 bits are divided as c = x, y, z [0] , . . . , z [7] ∈ F 82 × F 82 × (F 62 ) 8
+    which is used as input to the loclass_hash0 function. This function introduces some
+    obfuscation by performing a number of permutations, complement and modulo
+    operations, see Figure 2.5. Besides that, it checks for and removes patterns like
+    similar key bytes, which could produce a strong bias in the cipher. Finally, the
+    output of loclass_hash0 is the diversified card key k = k [0] , . . . , k [7] ∈ (F 82 ) 8 .
+
+**/
+#include "optimized_ikeys.h"
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include "poom_des.h"
+#include "optimized_cipherutils.h"
+
+static const uint8_t loclass_pi[35] = {0x0F, 0x17, 0x1B, 0x1D, 0x1E, 0x27, 0x2B, 0x2D, 0x2E,
+                                       0x33, 0x35, 0x39, 0x36, 0x3A, 0x3C, 0x47, 0x4B, 0x4D,
+                                       0x4E, 0x53, 0x55, 0x56, 0x59, 0x5A, 0x5C, 0x63, 0x65,
+                                       0x66, 0x69, 0x6A, 0x6C, 0x71, 0x72, 0x74, 0x78};
+
+/**
+ * @brief The key diversification algorithm uses 6-bit bytes.
+ * This implementation uses 64 bit uint to pack seven of them into one
+ * variable. When they are there, they are placed as follows:
+ * XXXX XXXX N0 .... N7, occupying the last 48 bits.
+ *
+ * This function picks out one from such a collection
+ * @param all
+ * @param n bitnumber
+ * @return
+ */
+static uint8_t loclass_getSixBitByte(uint64_t c, int n) {
+    return (c >> (42 - 6 * n)) & 0x3F;
+}
+
+/**
+ * @brief Puts back a six-bit 'byte' into a uint64_t.
+ * @param c buffer
+ * @param z the value to place there
+ * @param n bitnumber.
+ */
+static void loclass_pushbackSixBitByte(uint64_t* c, uint8_t z, int n) {
+    //0x XXXX YYYY ZZZZ ZZZZ ZZZZ
+    //             ^z0         ^z7
+    //z0:  1111 1100 0000 0000
+
+    uint64_t masked = z & 0x3F;
+    uint64_t eraser = 0x3F;
+    masked <<= 42 - 6 * n;
+    eraser <<= 42 - 6 * n;
+
+    //masked <<= 6*n;
+    //eraser <<= 6*n;
+
+    eraser = ~eraser;
+    (*c) &= eraser;
+    (*c) |= masked;
+}
+/**
+ * @brief Swaps the z-values.
+ * If the input value has format XYZ0Z1...Z7, the output will have the format
+ * XYZ7Z6...Z0 instead
+ * @param c
+ * @return
+ */
+static uint64_t loclass_swapZvalues(uint64_t c) {
+    uint64_t newz = 0;
+    loclass_pushbackSixBitByte(&newz, loclass_getSixBitByte(c, 0), 7);
+    loclass_pushbackSixBitByte(&newz, loclass_getSixBitByte(c, 1), 6);
+    loclass_pushbackSixBitByte(&newz, loclass_getSixBitByte(c, 2), 5);
+    loclass_pushbackSixBitByte(&newz, loclass_getSixBitByte(c, 3), 4);
+    loclass_pushbackSixBitByte(&newz, loclass_getSixBitByte(c, 4), 3);
+    loclass_pushbackSixBitByte(&newz, loclass_getSixBitByte(c, 5), 2);
+    loclass_pushbackSixBitByte(&newz, loclass_getSixBitByte(c, 6), 1);
+    loclass_pushbackSixBitByte(&newz, loclass_getSixBitByte(c, 7), 0);
+    newz |= (c & 0xFFFF000000000000);
+    return newz;
+}
+
+/**
+* @return 4 six-bit bytes chunked into a uint64_t,as 00..00a0a1a2a3
+*/
+static uint64_t loclass_ck(int i, int j, uint64_t z) {
+    if(i == 1 && j == -1) {
+        // loclass_ck(1, −1, z [0] . . . z [3] ) = z [0] . . . z [3]
+        return z;
+    } else if(j == -1) {
+        // loclass_ck(i, −1, z [0] . . . z [3] ) = loclass_ck(i − 1, i − 2, z [0] . . . z [3] )
+        return loclass_ck(i - 1, i - 2, z);
+    }
+
+    if(loclass_getSixBitByte(z, i) == loclass_getSixBitByte(z, j)) {
+        //loclass_ck(i, j − 1, z [0] . . . z [i] ← j . . . z [3] )
+        uint64_t newz = 0;
+        int c;
+        for(c = 0; c < 4; c++) {
+            uint8_t val = loclass_getSixBitByte(z, c);
+            if(c == i)
+                loclass_pushbackSixBitByte(&newz, j, c);
+            else
+                loclass_pushbackSixBitByte(&newz, val, c);
+        }
+        return loclass_ck(i, j - 1, newz);
+    } else {
+        return loclass_ck(i, j - 1, z);
+    }
+}
+/**
+
+    Definition 8.
+    Let the function check : (F 62 ) 8 → (F 62 ) 8 be defined as
+    check(z [0] . . . z [7] ) = loclass_ck(3, 2, z [0] . . . z [3] ) · loclass_ck(3, 2, z [4] . . . z [7] )
+
+    where loclass_ck : N × N × (F 62 ) 4 → (F 62 ) 4 is defined as
+
+        loclass_ck(1, −1, z [0] . . . z [3] ) = z [0] . . . z [3]
+        loclass_ck(i, −1, z [0] . . . z [3] ) = loclass_ck(i − 1, i − 2, z [0] . . . z [3] )
+        loclass_ck(i, j, z [0] . . . z [3] ) =
+        loclass_ck(i, j − 1, z [0] . . . z [i] ← j . . . z [3] ),  if z [i] = z [j] ;
+        loclass_ck(i, j − 1, z [0] . . . z [3] ), otherwise
+
+    otherwise.
+**/
+
+static uint64_t loclass_check(uint64_t z) {
+    //These 64 bits are divided as c = x, y, z [0] , . . . , z [7]
+
+    // loclass_ck(3, 2, z [0] . . . z [3] )
+    uint64_t ck1 = loclass_ck(3, 2, z);
+
+    // loclass_ck(3, 2, z [4] . . . z [7] )
+    uint64_t ck2 = loclass_ck(3, 2, z << 24);
+
+    //The loclass_ck function will place the values
+    // in the middle of z.
+    ck1 &= 0x00000000FFFFFF000000;
+    ck2 &= 0x00000000FFFFFF000000;
+
+    return ck1 | ck2 >> 24;
+}
+
+static void loclass_permute(
+    LoclassBitstreamIn_t* p_in,
+    uint64_t z,
+    int l,
+    int r,
+    LoclassBitstreamOut_t* out) {
+    if(loclass_bitsLeft(p_in) == 0) return;
+
+    bool pn = loclass_tailBit(p_in);
+    if(pn) { // pn = 1
+        uint8_t zl = loclass_getSixBitByte(z, l);
+
+        loclass_push6bits(out, zl + 1);
+        loclass_permute(p_in, z, l + 1, r, out);
+    } else { // otherwise
+        uint8_t zr = loclass_getSixBitByte(z, r);
+
+        loclass_push6bits(out, zr);
+        loclass_permute(p_in, z, l, r + 1, out);
+    }
+}
+
+/**
+ * @brief
+ *Definition 11. Let the function loclass_hash0 : F 82 × F 82 × (F 62 ) 8 → (F 82 ) 8 be defined as
+ *  loclass_hash0(x, y, z [0] . . . z [7] ) = k [0] . . . k [7] where
+ * z'[i] = (z[i] mod (63-i)) + i      i =  0...3
+ * z'[i+4] = (z[i+4] mod (64-i)) + i  i =  0...3
+ * ẑ = check(z');
+ * @param c
+ * @param k this is where the diversified key is put (should be 8 bytes)
+ * @return
+ */
+void loclass_hash0(uint64_t c, uint8_t k[8]) {
+    c = loclass_swapZvalues(c);
+
+    //These 64 bits are divided as c = x, y, z [0] , . . . , z [7]
+    // x = 8 bits
+    // y = 8 bits
+    // z0-z7 6 bits each : 48 bits
+    uint8_t x = (c & 0xFF00000000000000) >> 56;
+    uint8_t y = (c & 0x00FF000000000000) >> 48;
+    uint64_t zP = 0;
+
+    for(int n = 0; n < 4; n++) {
+        uint8_t zn = loclass_getSixBitByte(c, n);
+        uint8_t zn4 = loclass_getSixBitByte(c, n + 4);
+        uint8_t _zn = (zn % (63 - n)) + n;
+        uint8_t _zn4 = (zn4 % (64 - n)) + n;
+        loclass_pushbackSixBitByte(&zP, _zn, n);
+        loclass_pushbackSixBitByte(&zP, _zn4, n + 4);
+    }
+
+    uint64_t zCaret = loclass_check(zP);
+    uint8_t p = loclass_pi[x % 35];
+
+    if(x & 1) //Check if x7 is 1
+        p = ~p;
+
+    LoclassBitstreamIn_t p_in = {&p, 8, 0};
+    uint8_t outbuffer[] = {0, 0, 0, 0, 0, 0, 0, 0};
+    LoclassBitstreamOut_t out = {outbuffer, 0, 0};
+    loclass_permute(&p_in, zCaret, 0, 4, &out); //returns 48 bits? or 6 8-bytes
+
+    //Out is now a buffer containing six-bit bytes, should be 48 bits
+    // if all went well
+    //Shift z-values down onto the lower segment
+
+    uint64_t zTilde = loclass_x_bytes_to_num(outbuffer, sizeof(outbuffer));
+
+    zTilde >>= 16;
+
+    for(int i = 0; i < 8; i++) {
+        // the key on index i is first a bit from y
+        // then six bits from z,
+        // then a bit from p
+
+        // Init with zeroes
+        k[i] = 0;
+        // First, place yi leftmost in k
+        //k[i] |= (y  << i) & 0x80 ;
+
+        // First, place y(7-i) leftmost in k
+        k[i] |= (y << (7 - i)) & 0x80;
+
+        uint8_t zTilde_i = loclass_getSixBitByte(zTilde, i);
+        // zTildeI is now on the form 00XXXXXX
+        // with one leftshift, it'll be
+        // 0XXXXXX0
+        // So after leftshift, we can OR it into k
+        // However, when doing complement, we need to
+        // again MASK 0XXXXXX0 (0x7E)
+        zTilde_i <<= 1;
+
+        //Finally, add bit from p or p-mod
+        //Shift bit i into rightmost location (mask only after complement)
+        uint8_t p_i = p >> i & 0x1;
+
+        if(k[i]) { // yi = 1
+            k[i] |= ~zTilde_i & 0x7E;
+            k[i] |= p_i & 1;
+            k[i] += 1;
+
+        } else { // otherwise
+            k[i] |= zTilde_i & 0x7E;
+            k[i] |= (~p_i) & 1;
+        }
+    }
+}
+/**
+ * @brief Performs Elite-class key diversification
+ * @param csn
+ * @param key
+ * @param div_key
+ */
+void loclass_diversifyKey(const uint8_t* csn, const uint8_t* key, uint8_t* div_key) {
+    mbedtls_des_context loclass_ctx_enc;
+
+    // Prepare the DES key
+    mbedtls_des_setkey_enc(&loclass_ctx_enc, key);
+
+    uint8_t crypted_csn[8] = {0};
+
+    // Calculate DES(CSN, KEY)
+    mbedtls_des_crypt_ecb(&loclass_ctx_enc, csn, crypted_csn);
+
+    //Calculate HASH0(DES))
+    uint64_t c_csn = loclass_x_bytes_to_num(crypted_csn, sizeof(crypted_csn));
+
+    loclass_hash0(c_csn, div_key);
+}

--- a/applications/poom_picopass/src/loclass/optimized_ikeys.h
+++ b/applications/poom_picopass/src/loclass/optimized_ikeys.h
@@ -1,0 +1,66 @@
+//-----------------------------------------------------------------------------
+// Borrowed initially from https://github.com/holiman/loclass
+// More recently from https://github.com/RfidResearchGroup/proxmark3
+// Copyright (C) 2014 Martin Holst Swende
+// Copyright (C) Proxmark3 contributors. See AUTHORS.md for details.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// See LICENSE.txt for the text of the license.
+//-----------------------------------------------------------------------------
+// WARNING
+//
+// THIS CODE IS CREATED FOR EXPERIMENTATION AND EDUCATIONAL USE ONLY.
+//
+// USAGE OF THIS CODE IN OTHER WAYS MAY INFRINGE UPON THE INTELLECTUAL
+// PROPERTY OF OTHER PARTIES, SUCH AS INSIDE SECURE AND HID GLOBAL,
+// AND MAY EXPOSE YOU TO AN INFRINGEMENT ACTION FROM THOSE PARTIES.
+//
+// THIS CODE SHOULD NEVER BE USED TO INFRINGE PATENTS OR INTELLECTUAL PROPERTY RIGHTS.
+//-----------------------------------------------------------------------------
+// It is a reconstruction of the cipher engine used in iClass, and RFID techology.
+//
+// The implementation is based on the work performed by
+// Flavio D. Garcia, Gerhard de Koning Gans, Roel Verdult and
+// Milosch Meriac in the paper "Dismantling IClass".
+//-----------------------------------------------------------------------------
+#ifndef IKEYS_H
+#define IKEYS_H
+
+#include <inttypes.h>
+
+/**
+ * @brief
+ *Definition 11. Let the function loclass_hash0 : F 82 × F 82 × (F 62 ) 8 → (F 82 ) 8 be defined as
+ *  loclass_hash0(x, y, z [0] . . . z [7] ) = k [0] . . . k [7] where
+ * z'[i] = (z[i] mod (63-i)) + i        i =  0...3
+ * z'[i+4] = (z[i+4] mod (64-i)) + i    i =  0...3
+ * ẑ = check(z');
+ * @param c
+ * @param k this is where the diversified key is put (should be 8 bytes)
+ * @return
+ */
+void loclass_hash0(uint64_t c, uint8_t k[8]);
+/**
+ * @brief Performs Elite-class key diversification
+ * @param csn
+ * @param key
+ * @param div_key
+ */
+
+void loclass_diversifyKey(const uint8_t* csn, const uint8_t* key, uint8_t* div_key);
+/**
+ * @brief Permutes a key from standard NIST format to Iclass specific format
+ * @param key
+ * @param dest
+ */
+
+#endif // IKEYS_H

--- a/applications/poom_picopass/src/poom_des.c
+++ b/applications/poom_picopass/src/poom_des.c
@@ -1,0 +1,659 @@
+// SPDX-License-Identifier: Apache-2.0
+// Self-contained single-DES (ECB) extracted from mbedTLS des.c (Apache-2.0),
+// with CBC/3DES-CBC, self-test and mbedTLS config coupling removed. Kept because
+// ESP-IDF 6.1 (TF-PSA-Crypto 1.0) dropped MBEDTLS_DES_C, which loclass needs for
+// iCLASS key diversification. Symbol names match mbedtls_des_* so loclass calls
+// are unchanged.
+#include "poom_des.h"
+#include <string.h>
+#include <stdint.h>
+
+#define MBEDTLS_GET_UINT32_BE(b,i) ( ((uint32_t)((const unsigned char*)(b))[(i)]   << 24) | \
+                                     ((uint32_t)((const unsigned char*)(b))[(i)+1] << 16) | \
+                                     ((uint32_t)((const unsigned char*)(b))[(i)+2] <<  8) | \
+                                     ((uint32_t)((const unsigned char*)(b))[(i)+3]) )
+#define MBEDTLS_PUT_UINT32_BE(n,b,i) do { \
+    ((unsigned char*)(b))[(i)]   = (unsigned char)((n) >> 24); \
+    ((unsigned char*)(b))[(i)+1] = (unsigned char)((n) >> 16); \
+    ((unsigned char*)(b))[(i)+2] = (unsigned char)((n) >>  8); \
+    ((unsigned char*)(b))[(i)+3] = (unsigned char)((n)); } while(0)
+
+
+/*
+ * Expanded DES S-boxes
+ */
+static const uint32_t SB1[64] =
+{
+    0x01010400, 0x00000000, 0x00010000, 0x01010404,
+    0x01010004, 0x00010404, 0x00000004, 0x00010000,
+    0x00000400, 0x01010400, 0x01010404, 0x00000400,
+    0x01000404, 0x01010004, 0x01000000, 0x00000004,
+    0x00000404, 0x01000400, 0x01000400, 0x00010400,
+    0x00010400, 0x01010000, 0x01010000, 0x01000404,
+    0x00010004, 0x01000004, 0x01000004, 0x00010004,
+    0x00000000, 0x00000404, 0x00010404, 0x01000000,
+    0x00010000, 0x01010404, 0x00000004, 0x01010000,
+    0x01010400, 0x01000000, 0x01000000, 0x00000400,
+    0x01010004, 0x00010000, 0x00010400, 0x01000004,
+    0x00000400, 0x00000004, 0x01000404, 0x00010404,
+    0x01010404, 0x00010004, 0x01010000, 0x01000404,
+    0x01000004, 0x00000404, 0x00010404, 0x01010400,
+    0x00000404, 0x01000400, 0x01000400, 0x00000000,
+    0x00010004, 0x00010400, 0x00000000, 0x01010004
+};
+
+static const uint32_t SB2[64] =
+{
+    0x80108020, 0x80008000, 0x00008000, 0x00108020,
+    0x00100000, 0x00000020, 0x80100020, 0x80008020,
+    0x80000020, 0x80108020, 0x80108000, 0x80000000,
+    0x80008000, 0x00100000, 0x00000020, 0x80100020,
+    0x00108000, 0x00100020, 0x80008020, 0x00000000,
+    0x80000000, 0x00008000, 0x00108020, 0x80100000,
+    0x00100020, 0x80000020, 0x00000000, 0x00108000,
+    0x00008020, 0x80108000, 0x80100000, 0x00008020,
+    0x00000000, 0x00108020, 0x80100020, 0x00100000,
+    0x80008020, 0x80100000, 0x80108000, 0x00008000,
+    0x80100000, 0x80008000, 0x00000020, 0x80108020,
+    0x00108020, 0x00000020, 0x00008000, 0x80000000,
+    0x00008020, 0x80108000, 0x00100000, 0x80000020,
+    0x00100020, 0x80008020, 0x80000020, 0x00100020,
+    0x00108000, 0x00000000, 0x80008000, 0x00008020,
+    0x80000000, 0x80100020, 0x80108020, 0x00108000
+};
+
+static const uint32_t SB3[64] =
+{
+    0x00000208, 0x08020200, 0x00000000, 0x08020008,
+    0x08000200, 0x00000000, 0x00020208, 0x08000200,
+    0x00020008, 0x08000008, 0x08000008, 0x00020000,
+    0x08020208, 0x00020008, 0x08020000, 0x00000208,
+    0x08000000, 0x00000008, 0x08020200, 0x00000200,
+    0x00020200, 0x08020000, 0x08020008, 0x00020208,
+    0x08000208, 0x00020200, 0x00020000, 0x08000208,
+    0x00000008, 0x08020208, 0x00000200, 0x08000000,
+    0x08020200, 0x08000000, 0x00020008, 0x00000208,
+    0x00020000, 0x08020200, 0x08000200, 0x00000000,
+    0x00000200, 0x00020008, 0x08020208, 0x08000200,
+    0x08000008, 0x00000200, 0x00000000, 0x08020008,
+    0x08000208, 0x00020000, 0x08000000, 0x08020208,
+    0x00000008, 0x00020208, 0x00020200, 0x08000008,
+    0x08020000, 0x08000208, 0x00000208, 0x08020000,
+    0x00020208, 0x00000008, 0x08020008, 0x00020200
+};
+
+static const uint32_t SB4[64] =
+{
+    0x00802001, 0x00002081, 0x00002081, 0x00000080,
+    0x00802080, 0x00800081, 0x00800001, 0x00002001,
+    0x00000000, 0x00802000, 0x00802000, 0x00802081,
+    0x00000081, 0x00000000, 0x00800080, 0x00800001,
+    0x00000001, 0x00002000, 0x00800000, 0x00802001,
+    0x00000080, 0x00800000, 0x00002001, 0x00002080,
+    0x00800081, 0x00000001, 0x00002080, 0x00800080,
+    0x00002000, 0x00802080, 0x00802081, 0x00000081,
+    0x00800080, 0x00800001, 0x00802000, 0x00802081,
+    0x00000081, 0x00000000, 0x00000000, 0x00802000,
+    0x00002080, 0x00800080, 0x00800081, 0x00000001,
+    0x00802001, 0x00002081, 0x00002081, 0x00000080,
+    0x00802081, 0x00000081, 0x00000001, 0x00002000,
+    0x00800001, 0x00002001, 0x00802080, 0x00800081,
+    0x00002001, 0x00002080, 0x00800000, 0x00802001,
+    0x00000080, 0x00800000, 0x00002000, 0x00802080
+};
+
+static const uint32_t SB5[64] =
+{
+    0x00000100, 0x02080100, 0x02080000, 0x42000100,
+    0x00080000, 0x00000100, 0x40000000, 0x02080000,
+    0x40080100, 0x00080000, 0x02000100, 0x40080100,
+    0x42000100, 0x42080000, 0x00080100, 0x40000000,
+    0x02000000, 0x40080000, 0x40080000, 0x00000000,
+    0x40000100, 0x42080100, 0x42080100, 0x02000100,
+    0x42080000, 0x40000100, 0x00000000, 0x42000000,
+    0x02080100, 0x02000000, 0x42000000, 0x00080100,
+    0x00080000, 0x42000100, 0x00000100, 0x02000000,
+    0x40000000, 0x02080000, 0x42000100, 0x40080100,
+    0x02000100, 0x40000000, 0x42080000, 0x02080100,
+    0x40080100, 0x00000100, 0x02000000, 0x42080000,
+    0x42080100, 0x00080100, 0x42000000, 0x42080100,
+    0x02080000, 0x00000000, 0x40080000, 0x42000000,
+    0x00080100, 0x02000100, 0x40000100, 0x00080000,
+    0x00000000, 0x40080000, 0x02080100, 0x40000100
+};
+
+static const uint32_t SB6[64] =
+{
+    0x20000010, 0x20400000, 0x00004000, 0x20404010,
+    0x20400000, 0x00000010, 0x20404010, 0x00400000,
+    0x20004000, 0x00404010, 0x00400000, 0x20000010,
+    0x00400010, 0x20004000, 0x20000000, 0x00004010,
+    0x00000000, 0x00400010, 0x20004010, 0x00004000,
+    0x00404000, 0x20004010, 0x00000010, 0x20400010,
+    0x20400010, 0x00000000, 0x00404010, 0x20404000,
+    0x00004010, 0x00404000, 0x20404000, 0x20000000,
+    0x20004000, 0x00000010, 0x20400010, 0x00404000,
+    0x20404010, 0x00400000, 0x00004010, 0x20000010,
+    0x00400000, 0x20004000, 0x20000000, 0x00004010,
+    0x20000010, 0x20404010, 0x00404000, 0x20400000,
+    0x00404010, 0x20404000, 0x00000000, 0x20400010,
+    0x00000010, 0x00004000, 0x20400000, 0x00404010,
+    0x00004000, 0x00400010, 0x20004010, 0x00000000,
+    0x20404000, 0x20000000, 0x00400010, 0x20004010
+};
+
+static const uint32_t SB7[64] =
+{
+    0x00200000, 0x04200002, 0x04000802, 0x00000000,
+    0x00000800, 0x04000802, 0x00200802, 0x04200800,
+    0x04200802, 0x00200000, 0x00000000, 0x04000002,
+    0x00000002, 0x04000000, 0x04200002, 0x00000802,
+    0x04000800, 0x00200802, 0x00200002, 0x04000800,
+    0x04000002, 0x04200000, 0x04200800, 0x00200002,
+    0x04200000, 0x00000800, 0x00000802, 0x04200802,
+    0x00200800, 0x00000002, 0x04000000, 0x00200800,
+    0x04000000, 0x00200800, 0x00200000, 0x04000802,
+    0x04000802, 0x04200002, 0x04200002, 0x00000002,
+    0x00200002, 0x04000000, 0x04000800, 0x00200000,
+    0x04200800, 0x00000802, 0x00200802, 0x04200800,
+    0x00000802, 0x04000002, 0x04200802, 0x04200000,
+    0x00200800, 0x00000000, 0x00000002, 0x04200802,
+    0x00000000, 0x00200802, 0x04200000, 0x00000800,
+    0x04000002, 0x04000800, 0x00000800, 0x00200002
+};
+
+static const uint32_t SB8[64] =
+{
+    0x10001040, 0x00001000, 0x00040000, 0x10041040,
+    0x10000000, 0x10001040, 0x00000040, 0x10000000,
+    0x00040040, 0x10040000, 0x10041040, 0x00041000,
+    0x10041000, 0x00041040, 0x00001000, 0x00000040,
+    0x10040000, 0x10000040, 0x10001000, 0x00001040,
+    0x00041000, 0x00040040, 0x10040040, 0x10041000,
+    0x00001040, 0x00000000, 0x00000000, 0x10040040,
+    0x10000040, 0x10001000, 0x00041040, 0x00040000,
+    0x00041040, 0x00040000, 0x10041000, 0x00001000,
+    0x00000040, 0x10040040, 0x00001000, 0x00041040,
+    0x10001000, 0x00000040, 0x10000040, 0x10040000,
+    0x10040040, 0x10000000, 0x00040000, 0x10001040,
+    0x00000000, 0x10041040, 0x00040040, 0x10000040,
+    0x10040000, 0x10001000, 0x10001040, 0x00000000,
+    0x10041040, 0x00041000, 0x00041000, 0x00001040,
+    0x00001040, 0x00040040, 0x10000000, 0x10041000
+};
+
+/*
+ * PC1: left and right halves bit-swap
+ */
+static const uint32_t LHs[16] =
+{
+    0x00000000, 0x00000001, 0x00000100, 0x00000101,
+    0x00010000, 0x00010001, 0x00010100, 0x00010101,
+    0x01000000, 0x01000001, 0x01000100, 0x01000101,
+    0x01010000, 0x01010001, 0x01010100, 0x01010101
+};
+
+static const uint32_t RHs[16] =
+{
+    0x00000000, 0x01000000, 0x00010000, 0x01010000,
+    0x00000100, 0x01000100, 0x00010100, 0x01010100,
+    0x00000001, 0x01000001, 0x00010001, 0x01010001,
+    0x00000101, 0x01000101, 0x00010101, 0x01010101,
+};
+
+/*
+ * Initial Permutation macro
+ */
+#define DES_IP(X, Y)                                                       \
+    do                                                                    \
+    {                                                                     \
+        T = (((X) >>  4) ^ (Y)) & 0x0F0F0F0F; (Y) ^= T; (X) ^= (T <<  4); \
+        T = (((X) >> 16) ^ (Y)) & 0x0000FFFF; (Y) ^= T; (X) ^= (T << 16); \
+        T = (((Y) >>  2) ^ (X)) & 0x33333333; (X) ^= T; (Y) ^= (T <<  2); \
+        T = (((Y) >>  8) ^ (X)) & 0x00FF00FF; (X) ^= T; (Y) ^= (T <<  8); \
+        (Y) = (((Y) << 1) | ((Y) >> 31)) & 0xFFFFFFFF;                    \
+        T = ((X) ^ (Y)) & 0xAAAAAAAA; (Y) ^= T; (X) ^= T;                 \
+        (X) = (((X) << 1) | ((X) >> 31)) & 0xFFFFFFFF;                    \
+    } while (0)
+
+/*
+ * Final Permutation macro
+ */
+#define DES_FP(X, Y)                                                       \
+    do                                                                    \
+    {                                                                     \
+        (X) = (((X) << 31) | ((X) >> 1)) & 0xFFFFFFFF;                    \
+        T = ((X) ^ (Y)) & 0xAAAAAAAA; (X) ^= T; (Y) ^= T;                 \
+        (Y) = (((Y) << 31) | ((Y) >> 1)) & 0xFFFFFFFF;                    \
+        T = (((Y) >>  8) ^ (X)) & 0x00FF00FF; (X) ^= T; (Y) ^= (T <<  8); \
+        T = (((Y) >>  2) ^ (X)) & 0x33333333; (X) ^= T; (Y) ^= (T <<  2); \
+        T = (((X) >> 16) ^ (Y)) & 0x0000FFFF; (Y) ^= T; (X) ^= (T << 16); \
+        T = (((X) >>  4) ^ (Y)) & 0x0F0F0F0F; (Y) ^= T; (X) ^= (T <<  4); \
+    } while (0)
+
+/*
+ * DES round macro
+ */
+#define DES_ROUND(X, Y)                              \
+    do                                              \
+    {                                               \
+        T = *SK++ ^ (X);                            \
+        (Y) ^= SB8[(T) & 0x3F] ^            \
+               SB6[(T >>  8) & 0x3F] ^            \
+               SB4[(T >> 16) & 0x3F] ^            \
+               SB2[(T >> 24) & 0x3F];             \
+                                                    \
+        T = *SK++ ^ (((X) << 28) | ((X) >> 4));     \
+        (Y) ^= SB7[(T) & 0x3F] ^            \
+               SB5[(T >>  8) & 0x3F] ^            \
+               SB3[(T >> 16) & 0x3F] ^            \
+               SB1[(T >> 24) & 0x3F];             \
+    } while (0)
+
+#define SWAP(a, b)                                       \
+    do                                                  \
+    {                                                   \
+        uint32_t t = (a); (a) = (b); (b) = t; t = 0;    \
+    } while (0)
+
+void mbedtls_des_init(mbedtls_des_context *ctx)
+{
+    memset(ctx, 0, sizeof(mbedtls_des_context));
+}
+
+void mbedtls_des_free(mbedtls_des_context *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+
+    memset(ctx, 0, sizeof(mbedtls_des_context));
+}
+
+void mbedtls_des3_init(mbedtls_des3_context *ctx)
+{
+    memset(ctx, 0, sizeof(mbedtls_des3_context));
+}
+
+void mbedtls_des3_free(mbedtls_des3_context *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+
+    memset(ctx, 0, sizeof(mbedtls_des3_context));
+}
+
+static const unsigned char odd_parity_table[128] = { 1,  2,  4,  7,  8,
+                                                     11, 13, 14, 16, 19, 21, 22, 25, 26, 28, 31, 32,
+                                                     35, 37, 38, 41, 42, 44,
+                                                     47, 49, 50, 52, 55, 56, 59, 61, 62, 64, 67, 69,
+                                                     70, 73, 74, 76, 79, 81,
+                                                     82, 84, 87, 88, 91, 93, 94, 97, 98, 100, 103,
+                                                     104, 107, 109, 110, 112,
+                                                     115, 117, 118, 121, 122, 124, 127, 128, 131,
+                                                     133, 134, 137, 138, 140,
+                                                     143, 145, 146, 148, 151, 152, 155, 157, 158,
+                                                     161, 162, 164, 167, 168,
+                                                     171, 173, 174, 176, 179, 181, 182, 185, 186,
+                                                     188, 191, 193, 194, 196,
+                                                     199, 200, 203, 205, 206, 208, 211, 213, 214,
+                                                     217, 218, 220, 223, 224,
+                                                     227, 229, 230, 233, 234, 236, 239, 241, 242,
+                                                     244, 247, 248, 251, 253,
+                                                     254 };
+
+void mbedtls_des_key_set_parity(unsigned char key[MBEDTLS_DES_KEY_SIZE])
+{
+    int i;
+
+    for (i = 0; i < MBEDTLS_DES_KEY_SIZE; i++) {
+        key[i] = odd_parity_table[key[i] / 2];
+    }
+}
+
+/*
+ * Check the given key's parity, returns 1 on failure, 0 on SUCCESS
+ */
+int mbedtls_des_key_check_key_parity(const unsigned char key[MBEDTLS_DES_KEY_SIZE])
+{
+    int i;
+
+    for (i = 0; i < MBEDTLS_DES_KEY_SIZE; i++) {
+        if (key[i] != odd_parity_table[key[i] / 2]) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * Table of weak and semi-weak keys
+ *
+ * Source: http://en.wikipedia.org/wiki/Weak_key
+ *
+ * Weak:
+ * Alternating ones + zeros (0x0101010101010101)
+ * Alternating 'F' + 'E' (0xFEFEFEFEFEFEFEFE)
+ * '0xE0E0E0E0F1F1F1F1'
+ * '0x1F1F1F1F0E0E0E0E'
+ *
+ * Semi-weak:
+ * 0x011F011F010E010E and 0x1F011F010E010E01
+ * 0x01E001E001F101F1 and 0xE001E001F101F101
+ * 0x01FE01FE01FE01FE and 0xFE01FE01FE01FE01
+ * 0x1FE01FE00EF10EF1 and 0xE01FE01FF10EF10E
+ * 0x1FFE1FFE0EFE0EFE and 0xFE1FFE1FFE0EFE0E
+ * 0xE0FEE0FEF1FEF1FE and 0xFEE0FEE0FEF1FEF1
+ *
+ */
+
+#define WEAK_KEY_COUNT 16
+
+static const unsigned char weak_key_table[WEAK_KEY_COUNT][MBEDTLS_DES_KEY_SIZE] =
+{
+    { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 },
+    { 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE },
+    { 0x1F, 0x1F, 0x1F, 0x1F, 0x0E, 0x0E, 0x0E, 0x0E },
+    { 0xE0, 0xE0, 0xE0, 0xE0, 0xF1, 0xF1, 0xF1, 0xF1 },
+
+    { 0x01, 0x1F, 0x01, 0x1F, 0x01, 0x0E, 0x01, 0x0E },
+    { 0x1F, 0x01, 0x1F, 0x01, 0x0E, 0x01, 0x0E, 0x01 },
+    { 0x01, 0xE0, 0x01, 0xE0, 0x01, 0xF1, 0x01, 0xF1 },
+    { 0xE0, 0x01, 0xE0, 0x01, 0xF1, 0x01, 0xF1, 0x01 },
+    { 0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE },
+    { 0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01, 0xFE, 0x01 },
+    { 0x1F, 0xE0, 0x1F, 0xE0, 0x0E, 0xF1, 0x0E, 0xF1 },
+    { 0xE0, 0x1F, 0xE0, 0x1F, 0xF1, 0x0E, 0xF1, 0x0E },
+    { 0x1F, 0xFE, 0x1F, 0xFE, 0x0E, 0xFE, 0x0E, 0xFE },
+    { 0xFE, 0x1F, 0xFE, 0x1F, 0xFE, 0x0E, 0xFE, 0x0E },
+    { 0xE0, 0xFE, 0xE0, 0xFE, 0xF1, 0xFE, 0xF1, 0xFE },
+    { 0xFE, 0xE0, 0xFE, 0xE0, 0xFE, 0xF1, 0xFE, 0xF1 }
+};
+
+int mbedtls_des_key_check_weak(const unsigned char key[MBEDTLS_DES_KEY_SIZE])
+{
+    int i;
+
+    for (i = 0; i < WEAK_KEY_COUNT; i++) {
+        if (memcmp(weak_key_table[i], key, MBEDTLS_DES_KEY_SIZE) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+#if !defined(MBEDTLS_DES_SETKEY_ALT)
+void mbedtls_des_setkey(uint32_t SK[32], const unsigned char key[MBEDTLS_DES_KEY_SIZE])
+{
+    int i;
+    uint32_t X, Y, T;
+
+    X = MBEDTLS_GET_UINT32_BE(key, 0);
+    Y = MBEDTLS_GET_UINT32_BE(key, 4);
+
+    /*
+     * Permuted Choice 1
+     */
+    T =  ((Y >>  4) ^ X) & 0x0F0F0F0F;  X ^= T; Y ^= (T <<  4);
+    T =  ((Y) ^ X) & 0x10101010;  X ^= T; Y ^= (T);
+
+    X =   (LHs[(X) & 0xF] << 3) | (LHs[(X >>  8) & 0xF] << 2)
+        | (LHs[(X >> 16) & 0xF] << 1) | (LHs[(X >> 24) & 0xF])
+        | (LHs[(X >>  5) & 0xF] << 7) | (LHs[(X >> 13) & 0xF] << 6)
+        | (LHs[(X >> 21) & 0xF] << 5) | (LHs[(X >> 29) & 0xF] << 4);
+
+    Y =   (RHs[(Y >>  1) & 0xF] << 3) | (RHs[(Y >>  9) & 0xF] << 2)
+        | (RHs[(Y >> 17) & 0xF] << 1) | (RHs[(Y >> 25) & 0xF])
+        | (RHs[(Y >>  4) & 0xF] << 7) | (RHs[(Y >> 12) & 0xF] << 6)
+        | (RHs[(Y >> 20) & 0xF] << 5) | (RHs[(Y >> 28) & 0xF] << 4);
+
+    X &= 0x0FFFFFFF;
+    Y &= 0x0FFFFFFF;
+
+    /*
+     * calculate subkeys
+     */
+    for (i = 0; i < 16; i++) {
+        if (i < 2 || i == 8 || i == 15) {
+            X = ((X <<  1) | (X >> 27)) & 0x0FFFFFFF;
+            Y = ((Y <<  1) | (Y >> 27)) & 0x0FFFFFFF;
+        } else {
+            X = ((X <<  2) | (X >> 26)) & 0x0FFFFFFF;
+            Y = ((Y <<  2) | (Y >> 26)) & 0x0FFFFFFF;
+        }
+
+        *SK++ =   ((X <<  4) & 0x24000000) | ((X << 28) & 0x10000000)
+                | ((X << 14) & 0x08000000) | ((X << 18) & 0x02080000)
+                | ((X <<  6) & 0x01000000) | ((X <<  9) & 0x00200000)
+                | ((X >>  1) & 0x00100000) | ((X << 10) & 0x00040000)
+                | ((X <<  2) & 0x00020000) | ((X >> 10) & 0x00010000)
+                | ((Y >> 13) & 0x00002000) | ((Y >>  4) & 0x00001000)
+                | ((Y <<  6) & 0x00000800) | ((Y >>  1) & 0x00000400)
+                | ((Y >> 14) & 0x00000200) | ((Y) & 0x00000100)
+                | ((Y >>  5) & 0x00000020) | ((Y >> 10) & 0x00000010)
+                | ((Y >>  3) & 0x00000008) | ((Y >> 18) & 0x00000004)
+                | ((Y >> 26) & 0x00000002) | ((Y >> 24) & 0x00000001);
+
+        *SK++ =   ((X << 15) & 0x20000000) | ((X << 17) & 0x10000000)
+                | ((X << 10) & 0x08000000) | ((X << 22) & 0x04000000)
+                | ((X >>  2) & 0x02000000) | ((X <<  1) & 0x01000000)
+                | ((X << 16) & 0x00200000) | ((X << 11) & 0x00100000)
+                | ((X <<  3) & 0x00080000) | ((X >>  6) & 0x00040000)
+                | ((X << 15) & 0x00020000) | ((X >>  4) & 0x00010000)
+                | ((Y >>  2) & 0x00002000) | ((Y <<  8) & 0x00001000)
+                | ((Y >> 14) & 0x00000808) | ((Y >>  9) & 0x00000400)
+                | ((Y) & 0x00000200) | ((Y <<  7) & 0x00000100)
+                | ((Y >>  7) & 0x00000020) | ((Y >>  3) & 0x00000011)
+                | ((Y <<  2) & 0x00000004) | ((Y >> 21) & 0x00000002);
+    }
+}
+#endif /* !MBEDTLS_DES_SETKEY_ALT */
+
+/*
+ * DES key schedule (56-bit, encryption)
+ */
+int mbedtls_des_setkey_enc(mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE])
+{
+    mbedtls_des_setkey(ctx->sk, key);
+
+    return 0;
+}
+
+/*
+ * DES key schedule (56-bit, decryption)
+ */
+int mbedtls_des_setkey_dec(mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE])
+{
+    int i;
+
+    mbedtls_des_setkey(ctx->sk, key);
+
+    for (i = 0; i < 16; i += 2) {
+        SWAP(ctx->sk[i], ctx->sk[30 - i]);
+        SWAP(ctx->sk[i + 1], ctx->sk[31 - i]);
+    }
+
+    return 0;
+}
+
+static void des3_set2key(uint32_t esk[96],
+                         uint32_t dsk[96],
+                         const unsigned char key[MBEDTLS_DES_KEY_SIZE*2])
+{
+    int i;
+
+    mbedtls_des_setkey(esk, key);
+    mbedtls_des_setkey(dsk + 32, key + 8);
+
+    for (i = 0; i < 32; i += 2) {
+        dsk[i] = esk[30 - i];
+        dsk[i +  1] = esk[31 - i];
+
+        esk[i + 32] = dsk[62 - i];
+        esk[i + 33] = dsk[63 - i];
+
+        esk[i + 64] = esk[i];
+        esk[i + 65] = esk[i + 1];
+
+        dsk[i + 64] = dsk[i];
+        dsk[i + 65] = dsk[i + 1];
+    }
+}
+
+/*
+ * Triple-DES key schedule (112-bit, encryption)
+ */
+int mbedtls_des3_set2key_enc(mbedtls_des3_context *ctx,
+                             const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2])
+{
+    uint32_t sk[96];
+
+    des3_set2key(ctx->sk, sk, key);
+    memset(sk, 0, sizeof(sk));
+
+    return 0;
+}
+
+/*
+ * Triple-DES key schedule (112-bit, decryption)
+ */
+int mbedtls_des3_set2key_dec(mbedtls_des3_context *ctx,
+                             const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2])
+{
+    uint32_t sk[96];
+
+    des3_set2key(sk, ctx->sk, key);
+    memset(sk, 0, sizeof(sk));
+
+    return 0;
+}
+
+static void des3_set3key(uint32_t esk[96],
+                         uint32_t dsk[96],
+                         const unsigned char key[24])
+{
+    int i;
+
+    mbedtls_des_setkey(esk, key);
+    mbedtls_des_setkey(dsk + 32, key +  8);
+    mbedtls_des_setkey(esk + 64, key + 16);
+
+    for (i = 0; i < 32; i += 2) {
+        dsk[i] = esk[94 - i];
+        dsk[i +  1] = esk[95 - i];
+
+        esk[i + 32] = dsk[62 - i];
+        esk[i + 33] = dsk[63 - i];
+
+        dsk[i + 64] = esk[30 - i];
+        dsk[i + 65] = esk[31 - i];
+    }
+}
+
+/*
+ * Triple-DES key schedule (168-bit, encryption)
+ */
+int mbedtls_des3_set3key_enc(mbedtls_des3_context *ctx,
+                             const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3])
+{
+    uint32_t sk[96];
+
+    des3_set3key(ctx->sk, sk, key);
+    memset(sk, 0, sizeof(sk));
+
+    return 0;
+}
+
+/*
+ * Triple-DES key schedule (168-bit, decryption)
+ */
+int mbedtls_des3_set3key_dec(mbedtls_des3_context *ctx,
+                             const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3])
+{
+    uint32_t sk[96];
+
+    des3_set3key(sk, ctx->sk, key);
+    memset(sk, 0, sizeof(sk));
+
+    return 0;
+}
+
+/*
+ * DES-ECB block encryption/decryption
+ */
+#if !defined(MBEDTLS_DES_CRYPT_ECB_ALT)
+int mbedtls_des_crypt_ecb(mbedtls_des_context *ctx,
+                          const unsigned char input[8],
+                          unsigned char output[8])
+{
+    int i;
+    uint32_t X, Y, T, *SK;
+
+    SK = ctx->sk;
+
+    X = MBEDTLS_GET_UINT32_BE(input, 0);
+    Y = MBEDTLS_GET_UINT32_BE(input, 4);
+
+    DES_IP(X, Y);
+
+    for (i = 0; i < 8; i++) {
+        DES_ROUND(Y, X);
+        DES_ROUND(X, Y);
+    }
+
+    DES_FP(Y, X);
+
+    MBEDTLS_PUT_UINT32_BE(Y, output, 0);
+    MBEDTLS_PUT_UINT32_BE(X, output, 4);
+
+    return 0;
+}
+#endif /* !MBEDTLS_DES_CRYPT_ECB_ALT */
+
+
+/*
+ * 3DES-ECB block encryption/decryption
+ */
+#if !defined(MBEDTLS_DES3_CRYPT_ECB_ALT)
+int mbedtls_des3_crypt_ecb(mbedtls_des3_context *ctx,
+                           const unsigned char input[8],
+                           unsigned char output[8])
+{
+    int i;
+    uint32_t X, Y, T, *SK;
+
+    SK = ctx->sk;
+
+    X = MBEDTLS_GET_UINT32_BE(input, 0);
+    Y = MBEDTLS_GET_UINT32_BE(input, 4);
+
+    DES_IP(X, Y);
+
+    for (i = 0; i < 8; i++) {
+        DES_ROUND(Y, X);
+        DES_ROUND(X, Y);
+    }
+
+    for (i = 0; i < 8; i++) {
+        DES_ROUND(X, Y);
+        DES_ROUND(Y, X);
+    }
+
+    for (i = 0; i < 8; i++) {
+        DES_ROUND(Y, X);
+        DES_ROUND(X, Y);
+    }
+
+    DES_FP(Y, X);
+
+    MBEDTLS_PUT_UINT32_BE(Y, output, 0);
+    MBEDTLS_PUT_UINT32_BE(X, output, 4);
+
+    return 0;
+}
+#endif /* !MBEDTLS_DES3_CRYPT_ECB_ALT */
+
+

--- a/applications/poom_picopass/src/poom_des.h
+++ b/applications/poom_picopass/src/poom_des.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Standalone DES API extracted from mbedTLS (Apache-2.0). Symbol names match
+// mbedtls_des_* so the loclass code compiles unchanged. Needed because ESP-IDF
+// 6.1 (TF-PSA-Crypto 1.0) removed MBEDTLS_DES_C.
+
+#ifndef POOM_DES_H
+#define POOM_DES_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MBEDTLS_DES_KEY_SIZE 8
+
+typedef struct mbedtls_des_context {
+    uint32_t sk[32]; // DES subkeys
+} mbedtls_des_context;
+
+typedef struct mbedtls_des3_context {
+    uint32_t sk[96]; // 3DES subkeys
+} mbedtls_des3_context;
+
+void mbedtls_des_init(mbedtls_des_context* ctx);
+void mbedtls_des_free(mbedtls_des_context* ctx);
+void mbedtls_des3_init(mbedtls_des3_context* ctx);
+void mbedtls_des3_free(mbedtls_des3_context* ctx);
+
+void mbedtls_des_key_set_parity(unsigned char key[MBEDTLS_DES_KEY_SIZE]);
+int mbedtls_des_key_check_key_parity(const unsigned char key[MBEDTLS_DES_KEY_SIZE]);
+int mbedtls_des_key_check_weak(const unsigned char key[MBEDTLS_DES_KEY_SIZE]);
+
+void mbedtls_des_setkey(uint32_t SK[32], const unsigned char key[MBEDTLS_DES_KEY_SIZE]);
+int mbedtls_des_setkey_enc(mbedtls_des_context* ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE]);
+int mbedtls_des_setkey_dec(mbedtls_des_context* ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE]);
+
+int mbedtls_des3_set2key_enc(mbedtls_des3_context* ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2]);
+int mbedtls_des3_set2key_dec(mbedtls_des3_context* ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2]);
+int mbedtls_des3_set3key_enc(mbedtls_des3_context* ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3]);
+int mbedtls_des3_set3key_dec(mbedtls_des3_context* ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3]);
+
+int mbedtls_des_crypt_ecb(mbedtls_des_context* ctx, const unsigned char input[8], unsigned char output[8]);
+int mbedtls_des3_crypt_ecb(mbedtls_des3_context* ctx, const unsigned char input[8], unsigned char output[8]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // POOM_DES_H

--- a/applications/poom_picopass/src/poom_picopass.c
+++ b/applications/poom_picopass/src/poom_picopass.c
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// High-level PicoPass read flow. See poom_picopass.h.
+//
+// Flow (standard-keyed iCLASS tag):
+//   init picopass mode -> ACTALL -> IDENTIFY (anticollision CSN) -> SELECT
+//   -> read preauth blocks (CSN/config/epurse/AIA)
+//   -> diversify key, READCHECK e-purse, compute reader MAC, CHECK (auth)
+//   -> read AA1 application blocks (6..app_limit)
+
+#include "poom_picopass.h"
+#include "optimized_cipher.h"
+#include "poom_des.h"
+#include "poom_nfc_controller.h"  // poom_nfc_controller_start(): bring up RFAL/ST25R3916
+#include "rfal_picopass.h"
+#include <stdio.h>
+#include <string.h>
+
+// iCLASS transport key: 2-key 3DES that decrypts the credential blocks (7-9)
+// on standard "3DES-encrypted" cards.
+static const uint8_t iclass_3des_key[16] = {0xb4, 0x21, 0x2c, 0xca, 0xb7, 0xed,
+                                            0x21, 0x0f, 0x7b, 0x93, 0xd4, 0x59,
+                                            0x39, 0xc7, 0xdd, 0x36};
+
+#define PICOPASS_ENC_NONE 0x14
+#define PICOPASS_ENC_DES  0x15
+#define PICOPASS_ENC_3DES 0x17
+
+const uint8_t poom_picopass_standard_key[POOM_PICOPASS_BLOCK_LEN] = {
+    0xaf, 0xa7, 0x85, 0xa7, 0xda, 0xb3, 0x33, 0x78};
+
+static PoomPicopassStatus read_block(uint8_t idx,
+                                     uint8_t out[POOM_PICOPASS_BLOCK_LEN])
+{
+    rfalPicoPassReadBlockRes res;
+    if(rfalPicoPassPollerReadBlock(idx, &res) != RFAL_ERR_NONE)
+    {
+        return PoomPicopassErrRead;
+    }
+    memcpy(out, res.data, POOM_PICOPASS_BLOCK_LEN);
+    return PoomPicopassOk;
+}
+
+// Decode the HID PACS credential from AA1 blocks 6-9 (out->blocks[0..3]).
+static void poom_picopass_decode_pacs(PoomPicopassDump* out)
+{
+    if(out->app_block_count < 2)
+        return;  // need blocks 6 (config) and 7 (credential)
+    const uint8_t* blk6  = out->blocks[0];
+    const uint8_t* blk7  = out->blocks[1];
+    out->pacs_present    = true;
+    out->pacs_encryption = blk6[7];
+
+    if(out->pacs_encryption == PICOPASS_ENC_3DES)
+    {
+        mbedtls_des3_context ctx;
+        mbedtls_des3_init(&ctx);
+        mbedtls_des3_set2key_dec(&ctx, iclass_3des_key);
+        mbedtls_des3_crypt_ecb(&ctx, blk7, out->credential);
+        mbedtls_des3_free(&ctx);
+    }
+    else
+    {
+        // 3DES is the only encryption we decrypt. None (0x14), DES (0x15, not
+        // yet supported), or unknown: use the raw block as-is.
+        memcpy(out->credential, blk7, POOM_PICOPASS_BLOCK_LEN);
+    }
+
+    // Wiegand bit length = position of the leading sentinel 1-bit; then strip
+    // it.
+    uint32_t halves[2];
+    memcpy(halves, out->credential, sizeof(halves));
+    if(halves[0] == 0)
+    {
+        out->bit_length =
+            (uint8_t)(31 - __builtin_clz(__builtin_bswap32(halves[1])));
+    }
+    else
+    {
+        out->bit_length =
+            (uint8_t)(63 - __builtin_clz(__builtin_bswap32(halves[0])));
+    }
+    uint64_t sentinel = __builtin_bswap64(1ULL << out->bit_length);
+    uint64_t swapped;
+    memcpy(&swapped, out->credential, sizeof(swapped));
+    swapped ^= sentinel;
+    memcpy(out->credential, &swapped, sizeof(swapped));
+}
+
+PoomPicopassStatus poom_picopass_read(PoomPicopassDump* out,
+                                      const uint8_t* key,
+                                      bool elite)
+{
+    memset(out, 0, sizeof(*out));
+    if(key == NULL)
+        key = poom_picopass_standard_key;
+
+    // Bring up the NFC core (RFAL + ST25R3916) if it isn't already, so the
+    // command works standalone without a prior nfc-core-start. Idempotent.
+    if(!poom_nfc_controller_start())
+    {
+        return PoomPicopassErrInit;
+    }
+
+    if(rfalPicoPassPollerInitialize() != RFAL_ERR_NONE)
+    {
+        return PoomPicopassErrInit;
+    }
+
+    // Wake up. ACTALL returns an incomplete frame when a card is present; any
+    // other hard error means nothing is on the reader.
+    (void)rfalPicoPassPollerCheckPresence();
+
+    // Anticollision -> CSN.
+    rfalPicoPassIdentifyRes id;
+    if(rfalPicoPassPollerIdentify(&id) != RFAL_ERR_NONE)
+    {
+        return PoomPicopassErrIdentify;
+    }
+
+    // Select by the anticollision CSN -> real CSN (block 0).
+    rfalPicoPassSelectRes sel;
+    if(rfalPicoPassPollerSelect(id.CSN, &sel) != RFAL_ERR_NONE)
+    {
+        return PoomPicopassErrSelect;
+    }
+    memcpy(out->csn, sel.CSN, POOM_PICOPASS_BLOCK_LEN);
+
+    // Pre-auth readable blocks. Config (1), e-purse (2) and AIA (5) are
+    // readable without authentication on a standard card. A failed config read
+    // leaves app_limit at 0 so the app-block loop reads nothing.
+    bool config_ok =
+        read_block(POOM_PICOPASS_CONFIG_BLOCK, out->config) == PoomPicopassOk;
+    read_block(POOM_PICOPASS_EPURSE_BLOCK, out->epurse);
+    read_block(POOM_PICOPASS_AIA_BLOCK, out->aia);
+
+    // config byte 0 is the application limit: the first block of AA1 NOT to
+    // read (exclusive bound, so AA1 is blocks 6..app_limit-1).
+    out->app_limit = config_ok ? out->config[0] : 0;
+
+    // --- Authenticate against AA1 with the (diversified) key ---
+    loclass_iclass_calc_div_key((uint8_t*)out->csn, (uint8_t*)key, out->div_key,
+                                elite);
+
+    // READCHECK fetches the e-purse challenge (CCNR). cc_nr is 12 bytes: the
+    // 8-byte challenge followed by 4 zero bytes (the reader nonce, unused
+    // here).
+    rfalPicoPassReadCheckRes rc;
+    if(rfalPicoPassPollerReadCheck(&rc, POOM_PICOPASS_EPURSE_BLOCK,
+                                   /*use_credit=*/0) != RFAL_ERR_NONE)
+    {
+        return PoomPicopassErrReadCheck;
+    }
+    uint8_t cc_nr[12] = {0};
+    memcpy(cc_nr, rc.CCNR, 8);
+
+    // Reader MAC over cc_nr with the diversified key, then CHECK.
+    uint8_t mac[4];
+    loclass_opt_doReaderMAC(cc_nr, out->div_key, mac);
+
+    rfalPicoPassCheckRes chk;
+    if(rfalPicoPassPollerCheck(mac, &chk) != RFAL_ERR_NONE)
+    {
+        // Auth failed: still return what we read pre-auth.
+        out->authenticated = false;
+        return PoomPicopassErrAuth;
+    }
+    out->authenticated = true;
+
+    // Read AA1 application blocks from block 6 up to (but not including)
+    // app_limit.
+    uint8_t last  = out->app_limit;
+    uint8_t count = 0;
+    for(uint8_t blk = POOM_PICOPASS_PACS_CFG_BLOCK;
+        blk < last && count < POOM_PICOPASS_MAX_APP_BLOCKS; blk++, count++)
+    {
+        if(read_block(blk, out->blocks[count]) != PoomPicopassOk)
+        {
+            break;
+        }
+    }
+    out->app_block_count = count;
+
+    poom_picopass_decode_pacs(out);
+
+    return PoomPicopassOk;
+}
+
+static int hexline(char* p, int n, const char* label, const uint8_t* b)
+{
+    return snprintf(p, n, "%-8s %02X %02X %02X %02X %02X %02X %02X %02X\n",
+                    label, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]);
+}
+
+int poom_picopass_format(const PoomPicopassDump* dump, char* buf, int buf_len)
+{
+    char* p = buf;
+    int rem = buf_len;
+    int w;
+#define ADV(expr)             \
+    do                        \
+    {                         \
+        w = (expr);           \
+        if(w < 0 || w >= rem) \
+            return p - buf;   \
+        p += w;               \
+        rem -= w;             \
+    } while(0)
+
+    ADV(hexline(p, rem, "CSN", dump->csn));
+    ADV(hexline(p, rem, "CONFIG", dump->config));
+    ADV(hexline(p, rem, "EPURSE", dump->epurse));
+    ADV(hexline(p, rem, "AIA", dump->aia));
+    ADV(snprintf(p, rem, "AUTH     %s\n", dump->authenticated ? "yes" : "no"));
+    if(dump->pacs_present)
+    {
+        const char* enc = dump->pacs_encryption == 0x17   ? "3DES"
+                          : dump->pacs_encryption == 0x14 ? "none"
+                          : dump->pacs_encryption == 0x15 ? "DES"
+                                                          : "?";
+        ADV(snprintf(p, rem, "PACS     enc=%s bits=%u\n", enc,
+                     dump->bit_length));
+        ADV(snprintf(
+            p, rem, "CRED     %02X %02X %02X %02X %02X %02X %02X %02X\n",
+            dump->credential[0], dump->credential[1], dump->credential[2],
+            dump->credential[3], dump->credential[4], dump->credential[5],
+            dump->credential[6], dump->credential[7]));
+    }
+    for(uint8_t i = 0; i < dump->app_block_count; i++)
+    {
+        char lbl[8];
+        snprintf(lbl, sizeof(lbl), "BLK%02d", POOM_PICOPASS_PACS_CFG_BLOCK + i);
+        ADV(hexline(p, rem, lbl, dump->blocks[i]));
+    }
+#undef ADV
+    return p - buf;
+}

--- a/applications/poom_picopass/src/rfal_picopass.c
+++ b/applications/poom_picopass/src/rfal_picopass.c
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// PicoPass low-level poller on ST RFAL. See rfal_picopass.h.
+
+#include "rfal_picopass.h"
+#include <string.h>
+
+// All PicoPass frames use a manual TX CRC (the app supplies CRC bytes, or none
+// for the anticollision frames), keep the RX CRC so we can verify it, remove RX
+// parity, and leave AGC on.
+#define PICOPASS_TXRX_FLAGS                    \
+    ((uint32_t)RFAL_TXRX_FLAGS_CRC_TX_MANUAL | \
+     (uint32_t)RFAL_TXRX_FLAGS_AGC_ON |        \
+     (uint32_t)RFAL_TXRX_FLAGS_PAR_RX_REMV |   \
+     (uint32_t)RFAL_TXRX_FLAGS_CRC_RX_KEEP)
+
+// Per-frame wait time. 20 ms is generous; PicoPass answers in well under that.
+#define PICOPASS_FWT rfalConvMsTo1fc(20)
+
+// Guard / frame-delay times for PicoPass, set explicitly to the known-good
+// values from the original ST-RFAL port. TODO: prefer RFAL_GT_PICOPASS /
+// RFAL_FDT_*_PICOPASS if nfcal ever exposes them.
+#ifndef PICOPASS_GT
+#define PICOPASS_GT rfalConvMsTo1fc(1)  // ~1 ms guard after field-on
+#endif
+#ifndef PICOPASS_FDT_LISTEN
+#define PICOPASS_FDT_LISTEN 3400  // fc, min time before declaring RX timeout
+#endif
+#ifndef PICOPASS_FDT_POLL
+#define PICOPASS_FDT_POLL 4096  // fc, min gap between our frames
+#endif
+
+uint16_t rfalPicoPassCrc16(const uint8_t* buf, uint16_t length)
+{
+    // ISO13239 CRC (CCITT variant) with the PicoPass preset (0xE012).
+    uint16_t crc = RFAL_PICOPASS_CRC_PRELOAD;
+    for(uint16_t i = 0; i < length; i++)
+    {
+        uint8_t dat = buf[i];
+        dat ^= (uint8_t)(crc & 0xFFU);
+        dat ^= (uint8_t)(dat << 4);
+        crc = (uint16_t)((crc >> 8) ^ (((uint16_t)dat) << 8) ^
+                         (((uint16_t)dat) << 3) ^ (((uint16_t)dat) >> 4));
+    }
+    return crc;
+}
+
+ReturnCode rfalPicoPassPollerInitialize(void)
+{
+    ReturnCode ret;
+
+    ret = rfalSetMode(RFAL_MODE_POLL_PICOPASS, RFAL_BR_26p48, RFAL_BR_26p48);
+    if(ret != RFAL_ERR_NONE)
+    {
+        return ret;
+    }
+
+    rfalSetErrorHandling(RFAL_ERRORHANDLING_NONE);
+    rfalSetGT(PICOPASS_GT);
+    rfalSetFDTListen(PICOPASS_FDT_LISTEN);
+    rfalSetFDTPoll(PICOPASS_FDT_POLL);
+
+    // Energize the field and wait out the guard time before the first command.
+    return rfalFieldOnAndStartGT();
+}
+
+ReturnCode rfalPicoPassPollerCheckPresence(void)
+{
+    uint8_t txBuf[1]  = {RFAL_PICOPASS_CMD_ACTALL};
+    uint8_t rxBuf[32] = {0};
+    uint16_t recvLen  = 0;
+
+    // ACTALL is answered by an SOF only; an incomplete/short frame means a card
+    // is present. Caller treats INCOMPLETE_BYTE / TIMEOUT as "maybe present".
+    return rfalTransceiveBlockingTxRx(txBuf, sizeof(txBuf), rxBuf,
+                                      sizeof(rxBuf), &recvLen,
+                                      PICOPASS_TXRX_FLAGS, PICOPASS_FWT);
+}
+
+ReturnCode rfalPicoPassPollerIdentify(rfalPicoPassIdentifyRes* idRes)
+{
+    uint8_t txBuf[1] = {RFAL_PICOPASS_CMD_IDENTIFY};
+    uint16_t recvLen = 0;
+
+    return rfalTransceiveBlockingTxRx(txBuf, sizeof(txBuf), (uint8_t*)idRes,
+                                      sizeof(rfalPicoPassIdentifyRes), &recvLen,
+                                      PICOPASS_TXRX_FLAGS, PICOPASS_FWT);
+}
+
+ReturnCode rfalPicoPassPollerSelect(const uint8_t* csn,
+                                    rfalPicoPassSelectRes* selRes)
+{
+    uint8_t txBuf[1 + RFAL_PICOPASS_UID_LEN];
+    uint16_t recvLen = 0;
+
+    txBuf[0] = RFAL_PICOPASS_CMD_SELECT;
+    memcpy(&txBuf[1], csn, RFAL_PICOPASS_UID_LEN);
+
+    ReturnCode ret = rfalTransceiveBlockingTxRx(
+        txBuf, sizeof(txBuf), (uint8_t*)selRes, sizeof(rfalPicoPassSelectRes),
+        &recvLen, PICOPASS_TXRX_FLAGS, PICOPASS_FWT);
+
+    // The original port tolerated a timeout here on some tags.
+    if(ret == RFAL_ERR_TIMEOUT)
+    {
+        return RFAL_ERR_NONE;
+    }
+    return ret;
+}
+
+ReturnCode rfalPicoPassPollerReadCheck(rfalPicoPassReadCheckRes* rcRes,
+                                       uint8_t key_block_num,
+                                       int use_credit)
+{
+    uint8_t txBuf[2] = {use_credit ? RFAL_PICOPASS_CMD_READCHECK_KC
+                                   : RFAL_PICOPASS_CMD_READCHECK_KD,
+                        key_block_num};
+    uint16_t recvLen = 0;
+
+    ReturnCode ret = rfalTransceiveBlockingTxRx(
+        txBuf, sizeof(txBuf), (uint8_t*)rcRes, sizeof(rfalPicoPassReadCheckRes),
+        &recvLen, PICOPASS_TXRX_FLAGS, PICOPASS_FWT);
+
+    // The read-check response has no CRC, so a "CRC error" here is expected/OK.
+    if(ret == RFAL_ERR_CRC)
+    {
+        return RFAL_ERR_NONE;
+    }
+    return ret;
+}
+
+ReturnCode rfalPicoPassPollerCheck(const uint8_t* mac,
+                                   rfalPicoPassCheckRes* chkRes)
+{
+    uint8_t txBuf[9];
+    uint16_t recvLen = 0;
+
+    txBuf[0] = RFAL_PICOPASS_CMD_CHECK;
+    memset(&txBuf[1], 0, 4);  // 4 null bytes (challenge slot)
+    memcpy(&txBuf[5], mac, 4);
+
+    ReturnCode ret = rfalTransceiveBlockingTxRx(
+        txBuf, sizeof(txBuf), (uint8_t*)chkRes, sizeof(rfalPicoPassCheckRes),
+        &recvLen, PICOPASS_TXRX_FLAGS, PICOPASS_FWT);
+
+    // Like read-check, the CHECK response (4-byte MAC) carries no CRC, so a
+    // CRC error here is expected/OK.
+    if(ret == RFAL_ERR_CRC)
+    {
+        return RFAL_ERR_NONE;
+    }
+    return ret;
+}
+
+ReturnCode rfalPicoPassPollerReadBlock(uint8_t blockNum,
+                                       rfalPicoPassReadBlockRes* readRes)
+{
+    uint8_t txBuf[4] = {RFAL_PICOPASS_CMD_READ, blockNum, 0, 0};
+    uint16_t recvLen = 0;
+
+    uint16_t crc =
+        rfalPicoPassCrc16(&txBuf[1], 1);  // CRC over the block number only
+    txBuf[2] = (uint8_t)(crc & 0xFF);
+    txBuf[3] = (uint8_t)(crc >> 8);
+
+    return rfalTransceiveBlockingTxRx(txBuf, sizeof(txBuf), (uint8_t*)readRes,
+                                      sizeof(rfalPicoPassReadBlockRes),
+                                      &recvLen, PICOPASS_TXRX_FLAGS,
+                                      PICOPASS_FWT);
+}
+
+ReturnCode rfalPicoPassPollerWriteBlock(uint8_t blockNum,
+                                        const uint8_t data[8],
+                                        const uint8_t mac[4])
+{
+    // Authenticated UPDATE carries NO CRC: the 4-byte MAC is the integrity
+    // check. Frame is CMD + block + data[8] + mac[4] = 14 bytes (matches both
+    // references).
+    uint8_t txBuf[2 + 8 + 4];
+    uint16_t recvLen = 0;
+    rfalPicoPassReadBlockRes
+        resp;  // card echoes the block; response ignored, success = no error
+
+    txBuf[0] = RFAL_PICOPASS_CMD_WRITE;
+    txBuf[1] = blockNum;
+    memcpy(&txBuf[2], data, 8);
+    memcpy(&txBuf[10], mac, 4);
+
+    return rfalTransceiveBlockingTxRx(txBuf, sizeof(txBuf), (uint8_t*)&resp,
+                                      sizeof(resp), &recvLen,
+                                      PICOPASS_TXRX_FLAGS, PICOPASS_FWT);
+}


### PR DESCRIPTION
Reads standard-keyed iCLASS on the ST25R3916 through nfcal's RFAL, ported from my Flipper picopass app (plus loclass for the CSN key diversification and reader MAC). A menu entry under THE ZEN polls until a card is present, then shows the CSN and the PACS credential (bit length + sentinel-stripped hex).

This is trying to be minimally useful, and then we can iterate to add support for other keys (elite, etc), save, write, maybe emulation.

loclass is GPL-3.0, so the resulting firmware image is GPL; it's isolated in src/loclass/. DES is vendored (poom_des.c) because IDF 6.1's mbedTLS dropped MBEDTLS_DES_C.

LLM Disclosure: I used claude to 'write' a lot of this, but the entire PR diff was reviewed by me (to be fair, so much of this is either boiler plate loclass, boiler plate rfal, or boiler plate POOM app code that what is actually interesting is pretty small).