### PR TITLE
Decode PicoPass credentials to Wiegand FC/CN

### DIFF
--- a/applications/poom_app_pack/src/menu_picopass.c
+++ b/applications/poom_app_pack/src/menu_picopass.c
@@ -3,6 +3,7 @@
 // modeled on menu_nfc / menu_fw_info.
 
 #include "menu_picopass.h"
+#include "poom_nfc_controller.h"  // release the NFC core on exit
 #include "poom_picopass.h"
 
 #include <stdbool.h>
@@ -164,16 +165,39 @@ static void pp_draw_(void)
             poom_arduboy_set_cursor(0, 16);
             (void)poom_arduboy_print(l);
 
-            if(s_dump.pacs_present)
+            if(s_dump.wiegand_count > 0)
             {
-                (void)snprintf(l, sizeof(l), "BITS:%u", s_dump.bit_length);
+                // One line per matching format (37-bit yields two).
+                for(uint8_t i = 0; i < s_dump.wiegand_count; i++)
+                {
+                    (void)snprintf(
+                        l, sizeof(l), "%s F:%lu C:%llu",
+                        s_dump.wiegand[i].format,
+                        (unsigned long)s_dump.wiegand[i].facility_code,
+                        (unsigned long long)s_dump.wiegand[i].card_number);
+                    poom_arduboy_set_cursor(0, (int16_t)(28 + i * 11));
+                    (void)poom_arduboy_print(l);
+                }
+            }
+            else if(s_dump.pacs_present)
+            {
+                // Bad parity on a recognized length shows as e.g. "BITS:26!".
+                (void)snprintf(l, sizeof(l), "BITS:%u%s", s_dump.bit_length,
+                               s_dump.parity_error ? "!" : "");
                 poom_arduboy_set_cursor(0, 30);
                 (void)poom_arduboy_print(l);
-                (void)snprintf(l, sizeof(l), "%02X%02X%02X%02X%02X%02X%02X%02X",
-                               s_dump.credential[0], s_dump.credential[1],
-                               s_dump.credential[2], s_dump.credential[3],
-                               s_dump.credential[4], s_dump.credential[5],
-                               s_dump.credential[6], s_dump.credential[7]);
+                // Show only the significant bytes (drop leading zeros).
+                int nb = (s_dump.bit_length + 7) / 8;
+                if(nb < 1)
+                    nb = 1;
+                if(nb > 8)
+                    nb = 8;
+                char* q = l;
+                for(int i = 8 - nb; i < 8; i++)
+                {
+                    q += snprintf(q, sizeof(l) - (size_t)(q - l), "%02X",
+                                  s_dump.credential[i]);
+                }
                 poom_arduboy_set_cursor(0, 42);
                 (void)poom_arduboy_print(l);
             }
@@ -211,6 +235,8 @@ static void menu_picopass_exit_(void)
                                        s_sbus_user);
         s_buttons_subscribed = false;
     }
+    // Release the NFC core so we don't leave the RF field on after exiting.
+    poom_nfc_controller_stop();
     const uint8_t token = 1U;
     (void)poom_sbus_publish(POOM_MENU_RESUME_TOPIC, &token, sizeof(token), 0);
 }

--- a/applications/poom_picopass/CMakeLists.txt
+++ b/applications/poom_picopass/CMakeLists.txt
@@ -9,6 +9,7 @@ idf_component_register(
     SRCS
         "src/rfal_picopass.c"
         "src/poom_picopass.c"
+        "src/poom_wiegand.c"
         "src/poom_des.c"
         "src/loclass/optimized_cipher.c"
         "src/loclass/optimized_cipherutils.c"

--- a/applications/poom_picopass/include/poom_picopass.h
+++ b/applications/poom_picopass/include/poom_picopass.h
@@ -12,6 +12,7 @@ extern "C" {
 
 #define POOM_PICOPASS_BLOCK_LEN      8
 #define POOM_PICOPASS_MAX_APP_BLOCKS 32  // enough for 2KS/16KS AA1 dumps
+#define POOM_PICOPASS_MAX_WIEGAND    2  // 37-bit matches both H10302 and H10304
 
 // iCLASS block indices (AA1).
 #define POOM_PICOPASS_CSN_BLOCK      0
@@ -54,6 +55,17 @@ typedef struct
     uint8_t pacs_encryption;  // block6[7]: 0x14 none, 0x15 DES, 0x17 3DES
     uint8_t credential[POOM_PICOPASS_BLOCK_LEN];  // decrypted, sentinel removed
     uint8_t bit_length;                           // Wiegand bit length
+
+    // Decoded Wiegand credential(s). A 37-bit length is ambiguous (H10302 and
+    // H10304 share a parity scheme), so more than one format can validate.
+    uint8_t wiegand_count;  // number of parity-valid matches in wiegand[]
+    bool parity_error;      // a known length matched but none passed parity
+    struct
+    {
+        const char* format;  // e.g. "H10301"
+        uint32_t facility_code;
+        uint64_t card_number;
+    } wiegand[POOM_PICOPASS_MAX_WIEGAND];
 } PoomPicopassDump;
 
 // Read a standard-keyed iCLASS card into `out`.

--- a/applications/poom_picopass/src/poom_picopass.c
+++ b/applications/poom_picopass/src/poom_picopass.c
@@ -11,6 +11,7 @@
 #include "optimized_cipher.h"
 #include "poom_des.h"
 #include "poom_nfc_controller.h"  // poom_nfc_controller_start(): bring up RFAL/ST25R3916
+#include "poom_wiegand.h"
 #include "rfal_picopass.h"
 #include <stdio.h>
 #include <string.h>
@@ -84,6 +85,22 @@ static void poom_picopass_decode_pacs(PoomPicopassDump* out)
     memcpy(&swapped, out->credential, sizeof(swapped));
     swapped ^= sentinel;
     memcpy(out->credential, &swapped, sizeof(swapped));
+
+    // Decode every Wiegand format whose length matches and parity validates
+    // (37-bit is ambiguous and can yield both H10302 and H10304).
+    poom_wiegand_result_t w[POOM_PICOPASS_MAX_WIEGAND];
+    bool any_len = false;
+    int n        = poom_wiegand_decode(out->credential, out->bit_length, w,
+                                       POOM_PICOPASS_MAX_WIEGAND, &any_len);
+    out->wiegand_count = (uint8_t)n;
+    for(int i = 0; i < n; i++)
+    {
+        out->wiegand[i].format        = w[i].format;
+        out->wiegand[i].facility_code = w[i].facility_code;
+        out->wiegand[i].card_number   = w[i].card_number;
+    }
+    // A known length matched but nothing passed parity -> flag it.
+    out->parity_error = (n == 0) && any_len;
 }
 
 PoomPicopassStatus poom_picopass_read(PoomPicopassDump* out,
@@ -217,13 +234,27 @@ int poom_picopass_format(const PoomPicopassDump* dump, char* buf, int buf_len)
                           : dump->pacs_encryption == 0x14 ? "none"
                           : dump->pacs_encryption == 0x15 ? "DES"
                                                           : "?";
-        ADV(snprintf(p, rem, "PACS     enc=%s bits=%u\n", enc,
-                     dump->bit_length));
-        ADV(snprintf(
-            p, rem, "CRED     %02X %02X %02X %02X %02X %02X %02X %02X\n",
-            dump->credential[0], dump->credential[1], dump->credential[2],
-            dump->credential[3], dump->credential[4], dump->credential[5],
-            dump->credential[6], dump->credential[7]));
+        ADV(snprintf(p, rem, "PACS     enc=%s bits=%u%s\n", enc,
+                     dump->bit_length, dump->parity_error ? "!" : ""));
+        // Credential, significant bytes only (drop leading zeros).
+        int nb = (dump->bit_length + 7) / 8;
+        if(nb < 1)
+            nb = 1;
+        if(nb > 8)
+            nb = 8;
+        ADV(snprintf(p, rem, "%s", "CRED    "));
+        for(int i = 8 - nb; i < 8; i++)
+        {
+            ADV(snprintf(p, rem, " %02X", dump->credential[i]));
+        }
+        ADV(snprintf(p, rem, "%s", "\n"));
+        for(uint8_t i = 0; i < dump->wiegand_count; i++)
+        {
+            ADV(snprintf(p, rem, "WIEGAND  %s FC=%lu CN=%llu\n",
+                         dump->wiegand[i].format,
+                         (unsigned long)dump->wiegand[i].facility_code,
+                         (unsigned long long)dump->wiegand[i].card_number));
+        }
     }
     for(uint8_t i = 0; i < dump->app_block_count; i++)
     {

--- a/applications/poom_picopass/src/poom_wiegand.c
+++ b/applications/poom_picopass/src/poom_wiegand.c
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Wiegand credential decode. See poom_wiegand.h.
+
+#include "poom_wiegand.h"
+#include <string.h>
+
+typedef struct
+{
+    uint8_t length;  // number of encoded bits (excludes sentinel)
+    uint32_t top;    // bits 64..
+    uint32_t mid;    // bits 32..63
+    uint32_t bot;    // bits 0..31
+} wmo_t;
+
+// Parity bit to append (HID Wiegand convention):
+//   oddparity32(x)  -> bit that makes the total number of 1s odd
+//   evenparity32(x) -> bit that makes the total number of 1s even
+static uint8_t oddparity32(uint32_t x)
+{
+    return (uint8_t)(__builtin_parity(x) ^ 1u);  // 1 when x has an even count
+}
+static uint8_t evenparity32(uint32_t x)
+{
+    return (uint8_t)__builtin_parity(x);  // 1 when x has an odd count
+}
+
+// Bit at ordinal position `pos` (0 = highest transmitted bit).
+static uint8_t get_bit(const wmo_t* w, uint8_t pos)
+{
+    if(pos >= w->length)
+        return 0;
+    pos = (uint8_t)((w->length - pos) - 1);  // invert to bit weight
+    if(pos > 63)
+        return (uint8_t)((w->top >> (pos - 64)) & 1);
+    else if(pos > 31)
+        return (uint8_t)((w->mid >> (pos - 32)) & 1);
+    else
+        return (uint8_t)((w->bot >> pos) & 1);
+}
+
+static uint64_t get_field(const wmo_t* w, uint8_t first_bit, uint8_t len)
+{
+    uint64_t r = 0;
+    for(uint8_t i = 0; i < len; i++)
+    {
+        r = (r << 1) | get_bit(w, (uint8_t)(first_bit + i));
+    }
+    return r;
+}
+
+// Each unpacker returns: 0 = length doesn't match this format, 1 = length
+// matches but parity failed, 2 = length matches and parity is valid. On 1 or 2
+// it fills `out` with the (attempted) format/FC/CN.
+
+static int unpack_h10301(const wmo_t* w, poom_wiegand_result_t* out)
+{
+    if(w->length != 26)
+        return 0;
+    out->format        = "H10301";
+    out->card_number   = (w->bot >> 1) & 0xFFFF;
+    out->facility_code = (w->bot >> 17) & 0xFF;
+    bool ok            = (oddparity32((w->bot >> 1) & 0xFFF) == (w->bot & 1)) &&
+              (evenparity32((w->bot >> 13) & 0xFFF) == ((w->bot >> 25) & 1));
+    return ok ? 2 : 1;
+}
+
+static int unpack_c1k35s(const wmo_t* w, poom_wiegand_result_t* out)
+{
+    if(w->length != 35)
+        return 0;
+    out->format        = "C1k35s";
+    out->card_number   = (w->bot >> 1) & 0x000FFFFF;
+    out->facility_code = ((w->mid & 1) << 11) | (w->bot >> 21);
+    bool ok =
+        (evenparity32((w->mid & 0x1) ^ (w->bot & 0xB6DB6DB6)) ==
+         ((w->mid >> 1) & 1)) &&
+        (oddparity32((w->mid & 0x3) ^ (w->bot & 0x6DB6DB6C)) == (w->bot & 1)) &&
+        (oddparity32((w->mid & 0x3) ^ (w->bot & 0xFFFFFFFF)) ==
+         ((w->mid >> 2) & 1));
+    return ok ? 2 : 1;
+}
+
+static int unpack_h10302(const wmo_t* w, poom_wiegand_result_t* out)
+{
+    if(w->length != 37)
+        return 0;
+    out->format        = "H10302";
+    out->card_number   = get_field(w, 1, 35);
+    out->facility_code = 0;  // no facility code in this format
+    bool ok            = (get_bit(w, 0) == evenparity32(get_field(w, 1, 18))) &&
+              (get_bit(w, 36) == oddparity32(get_field(w, 18, 18)));
+    return ok ? 2 : 1;
+}
+
+static int unpack_h10304(const wmo_t* w, poom_wiegand_result_t* out)
+{
+    if(w->length != 37)
+        return 0;
+    out->format        = "H10304";
+    out->facility_code = (uint32_t)get_field(w, 1, 16);
+    out->card_number   = get_field(w, 17, 19);
+    bool ok            = (get_bit(w, 0) == evenparity32(get_field(w, 1, 18))) &&
+              (get_bit(w, 36) == oddparity32(get_field(w, 18, 18)));
+    return ok ? 2 : 1;
+}
+
+int poom_wiegand_decode(const uint8_t credential[8],
+                        uint8_t bit_length,
+                        poom_wiegand_result_t* out,
+                        int max,
+                        bool* any_length_match)
+{
+    // credential is big-endian on the wire; low 64 bits hold the field.
+    uint64_t v = 0;
+    for(int i = 0; i < 8; i++)
+        v = (v << 8) | credential[i];
+
+    wmo_t w = {
+        .length = bit_length,
+        .top    = 0,
+        .mid    = (uint32_t)(v >> 32),
+        .bot    = (uint32_t)(v & 0xFFFFFFFF),
+    };
+
+    static int (*const unpackers[])(const wmo_t*, poom_wiegand_result_t*) = {
+        unpack_h10301, unpack_c1k35s, unpack_h10302, unpack_h10304};
+
+    if(any_length_match)
+        *any_length_match = false;
+    int n = 0;
+    for(size_t i = 0; i < sizeof(unpackers) / sizeof(unpackers[0]); i++)
+    {
+        poom_wiegand_result_t r;
+        int s = unpackers[i](&w, &r);
+        if(s >= 1 && any_length_match)
+            *any_length_match = true;
+        if(s == 2 && n < max)
+            out[n++] = r;
+    }
+    return n;
+}

--- a/applications/poom_picopass/src/poom_wiegand.h
+++ b/applications/poom_picopass/src/poom_wiegand.h
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Wiegand credential decode for common HID formats (H10301, C1k35s, H10302,
+// H10304), operating on a sentinel-stripped PicoPass credential.
+
+#ifndef POOM_WIEGAND_H
+#define POOM_WIEGAND_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    const char* format;      // e.g. "H10301"
+    uint32_t facility_code;  // 0 if the format carries none
+    uint64_t card_number;
+} poom_wiegand_result_t;
+
+// Decode every known format whose length matches AND whose parity validates,
+// writing up to `max` results into `out` and returning the count. Some lengths
+// (37-bit H10302/H10304) are ambiguous and yield more than one match. If a
+// format's length matched but none passed parity, `*any_length_match` is set
+// true (caller can flag a parity error). Pass NULL for `any_length_match` to
+// ignore it.
+int poom_wiegand_decode(const uint8_t credential[8],
+                        uint8_t bit_length,
+                        poom_wiegand_result_t* out,
+                        int max,
+                        bool* any_length_match);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // POOM_WIEGAND_H


### PR DESCRIPTION
Builds on the picopass reader (#5): decodes the credential read from AA1 into an HID Wiegand facility code / card number.

- Formats: H10301 (26-bit), Corporate 1000 35-bit, and H10302/H10304 (37-bit), each parity-checked.
- 37-bit is ambiguous (H10302 and H10304 share a parity scheme), so I list every format that validates instead of guessing one.
- The PICOPASS menu shows each matching format with FC + CN. Unknown/other lengths, or a recognized length that fails parity, show the bit length + raw credential (a bad-parity length is flagged, e.g. `BITS:26!`).
- Adds `src/poom_wiegand.c` for the format unpackers; parity verified against the standard HID definitions.
- Also releases the NFC core when leaving the app so it doesn't leave the RF field on.

Draft while I test more card types. loclass (GPL-3.0) is already in the tree from #5, so no license change here.