### PR TITLE
wifi_scan: fix input latency, SSID truncation and duplicate APs; add scan abort

### DIFF
--- a/applications/poom_app_pack/src/menu_poom_wifi_scan.c
+++ b/applications/poom_app_pack/src/menu_poom_wifi_scan.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "esp_err.h"
+#include "esp_wifi.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "Arduboy2.h"
@@ -31,6 +32,22 @@
 #define MENU_POOM_WIFI_SCAN_INFO_HOLD_CYCLES (6U)
 #define MENU_POOM_WIFI_SCAN_PASS_MAX_LEN (63U)
 #define MENU_POOM_WIFI_SCAN_VISIBLE_AP_LINES (3U)
+
+/* AP rows: text from x=2 to the scroll arrows at x=120, 6 px/char -> 19 chars. */
+#define MENU_POOM_WIFI_SCAN_AP_ROW_X (2)
+#define MENU_POOM_WIFI_SCAN_ARROW_COL_X (120)
+#define MENU_POOM_WIFI_SCAN_SSID_VISIBLE_CHARS \
+    (((MENU_POOM_WIFI_SCAN_ARROW_COL_X) - (MENU_POOM_WIFI_SCAN_AP_ROW_X)) / (MENU_POOM_WIFI_SCAN_OLED_COL))
+#define MENU_POOM_WIFI_SCAN_SSID_LINE_BUF (MENU_POOM_WIFI_SCAN_SSID_VISIBLE_CHARS + 1U)
+
+/* Connect screen: full 128 px width less the "SSID:" prefix -> 16 chars. */
+#define MENU_POOM_WIFI_SCAN_CONNECT_PREFIX_CHARS (5)
+#define MENU_POOM_WIFI_SCAN_CONNECT_SSID_CHARS \
+    (((ARDUBOY_WIDTH - MENU_POOM_WIFI_SCAN_AP_ROW_X) / MENU_POOM_WIFI_SCAN_OLED_COL) - \
+     MENU_POOM_WIFI_SCAN_CONNECT_PREFIX_CHARS)
+
+#define MENU_POOM_WIFI_SCAN_MARQUEE_STEP_MS (350U)
+#define MENU_POOM_WIFI_SCAN_MARQUEE_GAP_CHARS (3U)
 
 #ifndef BTN_A
 #define BTN_A (0U)
@@ -95,6 +112,7 @@ static bool s_menu_poom_wifi_scan_exit_requested = false;
 static bool s_menu_poom_wifi_scan_scan_request_pending = false;
 static bool s_menu_poom_wifi_scan_connect_request_pending = false;
 static TaskHandle_t s_menu_poom_wifi_scan_status_task = NULL;
+static portMUX_TYPE s_menu_poom_wifi_scan_status_task_mux_ = portMUX_INITIALIZER_UNLOCKED;
 static char s_menu_poom_wifi_scan_sbus_user[] = "menu_poom_wifi_scan";
 static menu_poom_wifi_scan_state_t s_menu_poom_wifi_scan_state = MENU_POOM_WIFI_SCAN_STATE_SCANNING;
 static uint16_t s_menu_poom_wifi_scan_selected_ap = 0U;
@@ -105,8 +123,17 @@ static size_t s_menu_poom_wifi_scan_password_len = 0U;
 static poom_ui_keyboard_t s_menu_poom_wifi_scan_keyboard;
 static bool s_menu_poom_wifi_scan_save_yes_selected = true;
 static uint32_t s_menu_poom_wifi_scan_connect_start_ms = 0U;
-static uint8_t s_menu_poom_wifi_scan_info_hold_cycles = 0U;
+static uint32_t s_menu_poom_wifi_scan_info_deadline_ms_ = 0U;
 static char s_menu_poom_wifi_scan_status[22] = "Initializing";
+static uint32_t s_menu_poom_wifi_scan_marquee_start_ms_ = 0U;
+
+/* Maps a dedup-list index (what the UI shows/selects) to the raw scanner
+ * record index (what poom_wifi_scanner_get_ap_record() expects) that holds
+ * the strongest RSSI for that SSID. uint8_t is sized against
+ * POOM_WIFI_SCANNER_MAX_AP's documented Kconfig ceiling of 100, not the
+ * 20-entry default - it still covers that with headroom to spare. */
+static uint8_t s_menu_poom_wifi_scan_dedup_map_[POOM_WIFI_SCANNER_MAX_AP] = {0};
+static uint8_t s_menu_poom_wifi_scan_dedup_count_ = 0U;
 
 static esp_err_t menu_poom_wifi_scan_exit_(void);
 static void menu_poom_wifi_scan_button_cb_(const poom_sbus_msg_t *msg, void *user_ctx);
@@ -187,20 +214,63 @@ static const char *menu_poom_wifi_scan_selected_ssid_label_(void)
 }
 
 /**
- * @brief Internal helper for `menu_poom_wifi_scan_get_ap_count`.
+ * @brief Rebuilds the SSID-dedup map from the raw scanner records.
  *
- * @return uint16_t
+ * Records sharing a non-empty SSID collapse to a single entry, keeping the
+ * first (strongest RSSI, since esp_wifi_scan_get_ap_records() already
+ * returns records sorted by descending RSSI) occurrence - which preserves
+ * RSSI-descending order in the dedup map for free. Hidden networks (empty
+ * SSID) are never collapsed into each other; each raw record with an empty
+ * SSID gets its own dedup entry.
+ *
+ * @return void
  */
-static uint16_t menu_poom_wifi_scan_get_ap_count_(void)
+static void menu_poom_wifi_scan_build_dedup_map_(void)
 {
     poom_wifi_scanner_ap_records_t *records = poom_wifi_scanner_get_ap_records();
+    uint16_t raw_count;
+    uint16_t i;
+
+    s_menu_poom_wifi_scan_dedup_count_ = 0U;
 
     if(records == NULL)
     {
-        return 0U;
+        return;
     }
 
-    return records->count;
+    raw_count = records->count;
+    if(raw_count > POOM_WIFI_SCANNER_MAX_AP)
+    {
+        raw_count = POOM_WIFI_SCANNER_MAX_AP;
+    }
+
+    for(i = 0U; i < raw_count; i++)
+    {
+        const uint8_t *ssid_i = records->records[i].ssid;
+        bool is_hidden = (ssid_i[0] == 0U);
+        bool found = false;
+
+        if(!is_hidden)
+        {
+            uint16_t j;
+
+            for(j = 0U; j < s_menu_poom_wifi_scan_dedup_count_; j++)
+            {
+                const uint8_t *ssid_j = records->records[s_menu_poom_wifi_scan_dedup_map_[j]].ssid;
+                if(strncmp((const char *)ssid_i, (const char *)ssid_j, sizeof(records->records[i].ssid)) == 0)
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if(!found && (s_menu_poom_wifi_scan_dedup_count_ < POOM_WIFI_SCANNER_MAX_AP))
+        {
+            s_menu_poom_wifi_scan_dedup_map_[s_menu_poom_wifi_scan_dedup_count_] = (uint8_t)i;
+            s_menu_poom_wifi_scan_dedup_count_++;
+        }
+    }
 }
 
 /**
@@ -225,7 +295,8 @@ static void menu_poom_wifi_scan_clear_password_(void)
  */
 static void menu_poom_wifi_scan_enter_password_state_(void)
 {
-    wifi_ap_record_t *ap_record = poom_wifi_scanner_get_ap_record(s_menu_poom_wifi_scan_selected_ap);
+    uint16_t raw_index = s_menu_poom_wifi_scan_dedup_map_[s_menu_poom_wifi_scan_selected_ap];
+    wifi_ap_record_t *ap_record = poom_wifi_scanner_get_ap_record(raw_index);
 
     if(ap_record == NULL)
     {
@@ -268,6 +339,52 @@ static esp_err_t menu_poom_wifi_scan_store_credentials_(void)
 }
 
 /**
+ * @brief Builds the visible text for one AP row. Non-selected rows (and
+ *        selected rows whose SSID already fits) are simply truncated to
+ *        MENU_POOM_WIFI_SCAN_SSID_VISIBLE_CHARS. A selected row whose SSID
+ *        is longer than that scrolls over time, keyed off wall-clock time
+ *        so the marquee speed is independent of how often this is called.
+ *
+ * @param[out] out Destination buffer, at least MENU_POOM_WIFI_SCAN_SSID_LINE_BUF bytes.
+ * @param[in] out_len Size of out in bytes.
+ * @param[in] ssid Null-terminated SSID text to render.
+ * @param[in] selected true if this row is the highlighted row.
+ * @return void
+ */
+static void menu_poom_wifi_scan_build_row_text_(char *out, size_t out_len, const char *ssid, bool selected)
+{
+    size_t ssid_len;
+    size_t period;
+    uint32_t elapsed_ms;
+    size_t offset;
+    size_t i;
+
+    if((out == NULL) || (out_len == 0U))
+    {
+        return;
+    }
+
+    ssid_len = strlen(ssid);
+
+    if(!selected || (ssid_len <= MENU_POOM_WIFI_SCAN_SSID_VISIBLE_CHARS))
+    {
+        (void)snprintf(out, out_len, "%.*s", (int)MENU_POOM_WIFI_SCAN_SSID_VISIBLE_CHARS, ssid);
+        return;
+    }
+
+    period = ssid_len + MENU_POOM_WIFI_SCAN_MARQUEE_GAP_CHARS;
+    elapsed_ms = menu_poom_wifi_scan_now_ms_() - s_menu_poom_wifi_scan_marquee_start_ms_;
+    offset = (size_t)((elapsed_ms / MENU_POOM_WIFI_SCAN_MARQUEE_STEP_MS) % period);
+
+    for(i = 0U; (i < MENU_POOM_WIFI_SCAN_SSID_VISIBLE_CHARS) && (i < (out_len - 1U)); i++)
+    {
+        size_t src = (offset + i) % period;
+        out[i] = (src < ssid_len) ? ssid[src] : ' ';
+    }
+    out[i] = '\0';
+}
+
+/**
  * @brief Draws the current menu state.
  *
  * @return esp_err_t
@@ -292,8 +409,7 @@ static esp_err_t menu_poom_wifi_scan_draw_(void)
     {
         case MENU_POOM_WIFI_SCAN_STATE_SELECT_AP:
         {
-            poom_wifi_scanner_ap_records_t *records = poom_wifi_scanner_get_ap_records();
-            uint16_t count = (records != NULL) ? records->count : 0U;
+            uint16_t count = s_menu_poom_wifi_scan_dedup_count_;
 
             char count_buf[10];
             (void)snprintf(count_buf, sizeof(count_buf), "AP:%u", (unsigned)count);
@@ -327,9 +443,9 @@ static esp_err_t menu_poom_wifi_scan_draw_(void)
         case MENU_POOM_WIFI_SCAN_STATE_SELECT_AP:
         {
             poom_wifi_scanner_ap_records_t *records = poom_wifi_scanner_get_ap_records();
-            uint16_t count = (records != NULL) ? records->count : 0U;
+            uint16_t count = s_menu_poom_wifi_scan_dedup_count_;
 
-            if(count == 0U)
+            if((records == NULL) || (count == 0U))
             {
                 poom_arduboy_set_cursor(22, 26);
                 (void)poom_arduboy_print(F("No AP found"));
@@ -349,21 +465,23 @@ static esp_err_t menu_poom_wifi_scan_draw_(void)
                     break;
                 }
 
+                uint16_t raw_index = s_menu_poom_wifi_scan_dedup_map_[index];
                 char ssid[33];
-                menu_poom_wifi_scan_copy_ssid_(ssid, sizeof(ssid), records->records[index].ssid);
+                menu_poom_wifi_scan_copy_ssid_(ssid, sizeof(ssid), records->records[raw_index].ssid);
                 if(ssid[0] == '\0')
                 {
                     (void)snprintf(ssid, sizeof(ssid), "%s", "<hidden>");
                 }
 
-                char ap_line[16];
-                (void)snprintf(ap_line, sizeof(ap_line), "%.14s", ssid);
+                bool row_selected = (index == s_menu_poom_wifi_scan_selected_ap);
+                char ap_line[MENU_POOM_WIFI_SCAN_SSID_LINE_BUF];
+                menu_poom_wifi_scan_build_row_text_(ap_line, sizeof(ap_line), ssid, row_selected);
 
                 const int16_t y = (int16_t)(14 + (int16_t)row * 10);
-                poom_arduboy_set_cursor(2, y);
+                poom_arduboy_set_cursor(MENU_POOM_WIFI_SCAN_AP_ROW_X, y);
                 (void)poom_arduboy_print(ap_line);
 
-                if(index == s_menu_poom_wifi_scan_selected_ap)
+                if(row_selected)
                 {
                     poom_arduboy_fill_rect(0, (int16_t)(y - 1), ARDUBOY_WIDTH, 9, INVERT);
                 }
@@ -392,7 +510,9 @@ static esp_err_t menu_poom_wifi_scan_draw_(void)
         case MENU_POOM_WIFI_SCAN_STATE_CONNECTING:
             poom_arduboy_set_cursor(22, 26);
             (void)poom_arduboy_print(F("Connecting..."));
-            (void)snprintf(line1, sizeof(line1), "SSID:%.14s", menu_poom_wifi_scan_selected_ssid_label_());
+            (void)snprintf(line1, sizeof(line1), "SSID:%.*s",
+                          (int)MENU_POOM_WIFI_SCAN_CONNECT_SSID_CHARS,
+                          menu_poom_wifi_scan_selected_ssid_label_());
             poom_arduboy_set_cursor(2, 38);
             (void)poom_arduboy_print(line1);
             poom_arduboy_set_cursor(72, 56);
@@ -457,6 +577,7 @@ static esp_err_t menu_poom_wifi_scan_run_scan_(void)
     (void)menu_poom_wifi_scan_draw_();
 
     (void)poom_wifi_scanner_clear_ap_records();
+    s_menu_poom_wifi_scan_dedup_count_ = 0U;
     status = poom_wifi_scanner_scan();
     if(status != ESP_OK)
     {
@@ -465,9 +586,11 @@ static esp_err_t menu_poom_wifi_scan_run_scan_(void)
         return status;
     }
 
-    count = menu_poom_wifi_scan_get_ap_count_();
+    menu_poom_wifi_scan_build_dedup_map_();
+    count = s_menu_poom_wifi_scan_dedup_count_;
     s_menu_poom_wifi_scan_selected_ap = 0U;
     s_menu_poom_wifi_scan_ap_window_start = 0U;
+    s_menu_poom_wifi_scan_marquee_start_ms_ = menu_poom_wifi_scan_now_ms_();
     s_menu_poom_wifi_scan_state = MENU_POOM_WIFI_SCAN_STATE_SELECT_AP;
 
     if(count == 0U)
@@ -514,7 +637,7 @@ static void menu_poom_wifi_scan_update_connect_state_(void)
  */
 static void menu_poom_wifi_scan_handle_select_ap_button_(uint8_t button)
 {
-    uint16_t count = menu_poom_wifi_scan_get_ap_count_();
+    uint16_t count = s_menu_poom_wifi_scan_dedup_count_;
 
     if(count == 0U)
     {
@@ -530,6 +653,7 @@ static void menu_poom_wifi_scan_handle_select_ap_button_(uint8_t button)
         if(s_menu_poom_wifi_scan_selected_ap > 0U)
         {
             s_menu_poom_wifi_scan_selected_ap--;
+            s_menu_poom_wifi_scan_marquee_start_ms_ = menu_poom_wifi_scan_now_ms_();
         }
     }
     else if(button == BTN_DOWN)
@@ -537,6 +661,7 @@ static void menu_poom_wifi_scan_handle_select_ap_button_(uint8_t button)
         if(s_menu_poom_wifi_scan_selected_ap < (uint16_t)(count - 1U))
         {
             s_menu_poom_wifi_scan_selected_ap++;
+            s_menu_poom_wifi_scan_marquee_start_ms_ = menu_poom_wifi_scan_now_ms_();
         }
     }
     else if((button == BTN_A) || (button == BTN_RIGHT))
@@ -599,7 +724,16 @@ static void menu_poom_wifi_scan_handle_save_confirm_(void)
     }
 
     s_menu_poom_wifi_scan_state = MENU_POOM_WIFI_SCAN_STATE_INFO;
-    s_menu_poom_wifi_scan_info_hold_cycles = MENU_POOM_WIFI_SCAN_INFO_HOLD_CYCLES;
+    s_menu_poom_wifi_scan_info_deadline_ms_ =
+        menu_poom_wifi_scan_now_ms_() +
+        (MENU_POOM_WIFI_SCAN_INFO_HOLD_CYCLES * MENU_POOM_WIFI_SCAN_REFRESH_MS);
+
+    /* 0 is the disarmed sentinel; if the deadline lands exactly there at the
+     * ~49.7-day ms wrap, nudge it by 1 ms so auto-return still arms. */
+    if(s_menu_poom_wifi_scan_info_deadline_ms_ == 0U)
+    {
+        s_menu_poom_wifi_scan_info_deadline_ms_ = 1U;
+    }
 }
 
 /**
@@ -610,24 +744,29 @@ static void menu_poom_wifi_scan_handle_save_confirm_(void)
 static esp_err_t menu_poom_wifi_scan_exit_(void)
 {
     TaskHandle_t current_task = xTaskGetCurrentTaskHandle();
+    TaskHandle_t task_to_delete = NULL;
 
     s_menu_poom_wifi_scan_active = false;
     s_menu_poom_wifi_scan_exit_requested = false;
     s_menu_poom_wifi_scan_scan_request_pending = false;
     s_menu_poom_wifi_scan_connect_request_pending = false;
 
-    if(s_menu_poom_wifi_scan_status_task != NULL)
+    /* Claim the handle under the lock so a concurrent
+     * menu_poom_wifi_scan_notify_draw_() call either sees it before this
+     * clears it (and safely notifies) or sees NULL (and skips it) - never a
+     * handle this function is about to hand to vTaskDelete(). The delete
+     * itself happens after the section is released. */
+    portENTER_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+    if((s_menu_poom_wifi_scan_status_task != NULL) && (s_menu_poom_wifi_scan_status_task != current_task))
     {
-        if(s_menu_poom_wifi_scan_status_task != current_task)
-        {
-            TaskHandle_t status_task = s_menu_poom_wifi_scan_status_task;
-            s_menu_poom_wifi_scan_status_task = NULL;
-            vTaskDelete(status_task);
-        }
-        else
-        {
-            s_menu_poom_wifi_scan_status_task = NULL;
-        }
+        task_to_delete = s_menu_poom_wifi_scan_status_task;
+    }
+    s_menu_poom_wifi_scan_status_task = NULL;
+    portEXIT_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+
+    if(task_to_delete != NULL)
+    {
+        vTaskDelete(task_to_delete);
     }
 
     if(s_menu_poom_wifi_scan_buttons_subscribed)
@@ -678,6 +817,25 @@ static void menu_poom_wifi_scan_wifi_evt_cb_(const poom_wifi_ctrl_evt_info_t *in
 }
 
 /**
+ * @brief Wakes the draw task so a state change repaints without waiting for
+ *        the next periodic refresh tick.
+ *
+ * @return void
+ */
+static void menu_poom_wifi_scan_notify_draw_(void)
+{
+    /* Read the handle and give the notification under the same lock that
+     * clears it, so the status task cannot self-delete between the NULL check
+     * and the give. xTaskNotifyGive() never blocks, so it is spinlock-safe. */
+    portENTER_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+    if(s_menu_poom_wifi_scan_status_task != NULL)
+    {
+        (void)xTaskNotifyGive(s_menu_poom_wifi_scan_status_task);
+    }
+    portEXIT_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+}
+
+/**
  * @brief Handles button events for this menu module.
  *
  * @param[in] msg Parameter passed to the helper.
@@ -718,7 +876,20 @@ static void menu_poom_wifi_scan_button_cb_(const poom_sbus_msg_t *msg, void *use
             else
             {
                 s_menu_poom_wifi_scan_exit_requested = true;
+
+                /* poom_wifi_scanner runs esp_wifi_scan_start(NULL, true), so the
+                 * status task is parked inside it for the whole sweep and cannot
+                 * see the exit request until the scan returns - several seconds
+                 * of an apparently dead B button. Aborting the scan releases the
+                 * blocked call so the loop reaches the exit check immediately.
+                 * The scanner module is shared by four other callers, so this
+                 * cancels from the caller rather than changing its semantics. */
+                if(s_menu_poom_wifi_scan_state == MENU_POOM_WIFI_SCAN_STATE_SCANNING)
+                {
+                    (void)esp_wifi_scan_stop();
+                }
             }
+            menu_poom_wifi_scan_notify_draw_();
             return;
         }
 
@@ -758,19 +929,25 @@ static void menu_poom_wifi_scan_button_cb_(const poom_sbus_msg_t *msg, void *use
             default:
                 break;
         }
+
+        menu_poom_wifi_scan_notify_draw_();
+        return;
     }
-    else if((button_msg.button == BTN_A) &&
-            menu_poom_wifi_scan_is_long_press_event_(button_msg.event))
+
+    if((button_msg.button == BTN_A) &&
+       menu_poom_wifi_scan_is_long_press_event_(button_msg.event))
     {
         if(s_menu_poom_wifi_scan_state == MENU_POOM_WIFI_SCAN_STATE_SELECT_AP)
         {
             menu_poom_wifi_scan_enter_password_state_();
+            menu_poom_wifi_scan_notify_draw_();
             return;
         }
 
         if(s_menu_poom_wifi_scan_state == MENU_POOM_WIFI_SCAN_STATE_ASK_SAVE)
         {
             menu_poom_wifi_scan_handle_save_confirm_();
+            menu_poom_wifi_scan_notify_draw_();
             return;
         }
 
@@ -782,6 +959,8 @@ static void menu_poom_wifi_scan_button_cb_(const poom_sbus_msg_t *msg, void *use
             s_menu_poom_wifi_scan_state = MENU_POOM_WIFI_SCAN_STATE_CONNECTING;
             (void)snprintf(s_menu_poom_wifi_scan_status, sizeof(s_menu_poom_wifi_scan_status), "Connecting...");
         }
+
+        menu_poom_wifi_scan_notify_draw_();
     }
 }
 
@@ -807,6 +986,14 @@ static void menu_poom_wifi_scan_status_task_(void *task_arg)
         {
             s_menu_poom_wifi_scan_scan_request_pending = false;
             (void)menu_poom_wifi_scan_run_scan_();
+
+            /* If B aborted the scan, esp_wifi_scan_stop() made the blocking
+             * scan return an error and run_scan_() painted "Scan failed";
+             * loop back to the exit check instead of drawing that transient. */
+            if(s_menu_poom_wifi_scan_exit_requested)
+            {
+                continue;
+            }
         }
 
         if(s_menu_poom_wifi_scan_connect_request_pending)
@@ -840,21 +1027,33 @@ static void menu_poom_wifi_scan_status_task_(void *task_arg)
         {
             menu_poom_wifi_scan_update_connect_state_();
         }
-        else if((s_menu_poom_wifi_scan_state == MENU_POOM_WIFI_SCAN_STATE_INFO) &&
-                (s_menu_poom_wifi_scan_info_hold_cycles > 0U))
-        {
-            s_menu_poom_wifi_scan_info_hold_cycles--;
-            if(s_menu_poom_wifi_scan_info_hold_cycles == 0U)
-            {
-                s_menu_poom_wifi_scan_exit_requested = true;
-            }
-        }
 
         (void)menu_poom_wifi_scan_draw_();
-        vTaskDelay(pdMS_TO_TICKS(MENU_POOM_WIFI_SCAN_REFRESH_MS));
+
+        /* Wait for a refresh tick or a button notify. The INFO auto-return is
+         * timed off the wall clock (deadline set on entry), not this tick count,
+         * so a button press waking us early cannot shorten or extend the hold. */
+        (void)ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(MENU_POOM_WIFI_SCAN_REFRESH_MS));
+
+        if((s_menu_poom_wifi_scan_state == MENU_POOM_WIFI_SCAN_STATE_INFO) &&
+           (s_menu_poom_wifi_scan_info_deadline_ms_ != 0U) &&
+           ((int32_t)(menu_poom_wifi_scan_now_ms_() - s_menu_poom_wifi_scan_info_deadline_ms_) >= 0))
+        {
+            s_menu_poom_wifi_scan_exit_requested = true;
+        }
     }
 
-    s_menu_poom_wifi_scan_status_task = NULL;
+    /* Clear only our OWN handle. menu_poom_wifi_scan_exit_() may already have
+     * detached us, letting menu_poom_wifi_scan_show() publish a replacement
+     * task before we reach here; an unconditional clear would orphan it, and
+     * a later show() could then run a second task over the same globals,
+     * scanner and framebuffer. */
+    portENTER_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+    if(s_menu_poom_wifi_scan_status_task == xTaskGetCurrentTaskHandle())
+    {
+        s_menu_poom_wifi_scan_status_task = NULL;
+    }
+    portEXIT_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
     vTaskDelete(NULL);
 }
 
@@ -868,7 +1067,7 @@ void menu_poom_wifi_scan_show(void)
     s_menu_poom_wifi_scan_selected_ap = 0U;
     s_menu_poom_wifi_scan_ap_window_start = 0U;
     s_menu_poom_wifi_scan_save_yes_selected = true;
-    s_menu_poom_wifi_scan_info_hold_cycles = 0U;
+    s_menu_poom_wifi_scan_info_deadline_ms_ = 0U;
     (void)memset(s_menu_poom_wifi_scan_selected_ssid, 0, sizeof(s_menu_poom_wifi_scan_selected_ssid));
     menu_poom_wifi_scan_clear_password_();
     (void)snprintf(s_menu_poom_wifi_scan_status, sizeof(s_menu_poom_wifi_scan_status), "Scanning...");
@@ -893,13 +1092,37 @@ void menu_poom_wifi_scan_show(void)
         }
     }
 
-    if(s_menu_poom_wifi_scan_status_task == NULL)
+    /* Create into a local handle and publish it under the mux, so the store is
+     * serialised with the notify and teardown paths rather than relying on this
+     * being the only caller. xTaskCreate() stays outside the critical section
+     * because it allocates. */
+    bool needs_task;
+    portENTER_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+    needs_task = (s_menu_poom_wifi_scan_status_task == NULL);
+    portEXIT_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+
+    if(needs_task)
     {
-        (void)xTaskCreate(menu_poom_wifi_scan_status_task_,
-                          "menu_wifi_scan",
-                          MENU_POOM_WIFI_SCAN_STATUS_STACK,
-                          NULL,
-                          MENU_POOM_WIFI_SCAN_STATUS_PRIO,
-                          &s_menu_poom_wifi_scan_status_task);
+        TaskHandle_t created = NULL;
+        if(xTaskCreate(menu_poom_wifi_scan_status_task_,
+                       "menu_wifi_scan",
+                       MENU_POOM_WIFI_SCAN_STATUS_STACK,
+                       NULL,
+                       MENU_POOM_WIFI_SCAN_STATUS_PRIO,
+                       &created) == pdPASS)
+        {
+            portENTER_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+            if(s_menu_poom_wifi_scan_status_task == NULL)
+            {
+                s_menu_poom_wifi_scan_status_task = created;
+                created = NULL;
+            }
+            portEXIT_CRITICAL(&s_menu_poom_wifi_scan_status_task_mux_);
+
+            if(created != NULL)
+            {
+                vTaskDelete(created);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

The Wi-Fi scan UI has three rough edges you hit right away on hardware, and B does nothing during a scan.

## Changes

- **Input latency:** repaint on button press (task notify) instead of only on the refresh tick.
- **Long SSIDs:** the selected row marquee-scrolls; others truncate to the visible width.
- **Duplicate APs:** rows sharing an SSID collapse to one (strongest RSSI kept); hidden networks are not merged.
- **B aborts a scan:** `esp_wifi_scan_start(..., block=true)` parks the status task, so B calls `esp_wifi_scan_stop()` to release it. Done from the caller, so the shared scanner is unchanged.
- **Status-task lifecycle:** handle read/notify/clear under one spinlock, closing a use-after-teardown window.
- **INFO auto-return:** timed off the wall clock, so mashing buttons can't hold the screen open.

## Testing

Builds for `esp32c5` on ESP-IDF v6.1-rc1 and flashed to hardware: latency, marquee, dedup, and B-abort all confirmed.

## Known limitation

Small B-abort race: if B lands in the brief `SELECT_AP -> scan-start` window, `esp_wifi_scan_stop()` can no-op and that scan runs uncancelled (benign: latency returns for that one scan, no crash). A full fix needs a non-blocking API in the shared `poom_wifi_scanner` (four other callers); out of scope here.
