### PR TITLE
Save PicoPass dumps to the SD card

### DIFF
--- a/applications/poom_app_pack/src/menu_picopass.c
+++ b/applications/poom_app_pack/src/menu_picopass.c
@@ -66,8 +66,10 @@ typedef enum
     PP_MENU,
     PP_READING,
     PP_RESULT,
-    PP_INFO,  // decoded card metadata (security, key, SIO)
-    PP_RAW    // paged raw block hex
+    PP_INFO,    // decoded card metadata (security, key, SIO)
+    PP_RAW,     // paged raw block hex
+    PP_SAVING,  // writing the dump to SD
+    PP_SAVED    // save outcome
 } pp_state_t;
 
 // Submenu options. Add real entries (Emulate, Write, ...) here as they land.
@@ -88,6 +90,10 @@ static char s_sbus_user[]          = "menu_picopass";
 static pp_state_t s_state          = PP_MENU;
 static pp_opt_t s_opt              = PP_OPT_READ;
 static int s_raw_page              = 0;  // current page in the PP_RAW hex view
+static esp_err_t s_save_status     = ESP_OK;
+static char s_save_path[64]        = {0};
+static bool s_sd_ok                = false;  // SD usable (probed on Info entry)
+static bool s_sd_probe_pending     = false;
 static PoomPicopassStatus s_status = PoomPicopassOk;
 static PoomPicopassDump s_dump;
 
@@ -118,6 +124,19 @@ static const char* status_short(PoomPicopassStatus s)
 static bool status_is_no_card(PoomPicopassStatus s)
 {
     return (s == PoomPicopassErrNoCard) || (s == PoomPicopassErrIdentify);
+}
+
+static const char* save_error_text(esp_err_t e)
+{
+    switch(e)
+    {
+        case ESP_ERR_NOT_SUPPORTED:
+            return "Format needed";
+        case ESP_ERR_NOT_FOUND:
+            return "No SD card";
+        default:
+            return "Save failed";
+    }
 }
 
 static void pp_draw_header_(void)
@@ -312,7 +331,13 @@ static void pp_draw_(void)
 
         poom_arduboy_set_cursor(0, 56);
         (void)poom_arduboy_print(F("B:BACK"));
-        poom_arduboy_set_cursor(72, 56);
+        // Only offer Save when an SD card is usable.
+        if(s_sd_ok)
+        {
+            poom_arduboy_set_cursor(44, 56);
+            (void)poom_arduboy_print(F("^:SAVE"));
+        }
+        poom_arduboy_set_cursor(92, 56);
         (void)poom_arduboy_print(F("v:RAW"));
     }
     else if(s_state == PP_RAW)
@@ -343,6 +368,31 @@ static void pp_draw_(void)
         (void)poom_arduboy_print(foot);
         poom_arduboy_set_cursor(100, 56);
         (void)poom_arduboy_print(F("^v"));
+    }
+    else if(s_state == PP_SAVING)
+    {
+        poom_arduboy_set_cursor(0, 28);
+        (void)poom_arduboy_print(F("Saving..."));
+    }
+    else if(s_state == PP_SAVED)
+    {
+        if(s_save_status == ESP_OK)
+        {
+            poom_arduboy_set_cursor(0, 20);
+            (void)poom_arduboy_print(F("Saved"));
+            // Show the file name (drop the "/picopass/" directory prefix).
+            const char* name = strrchr(s_save_path, '/');
+            name             = (name != NULL) ? name + 1 : s_save_path;
+            poom_arduboy_set_cursor(0, 32);
+            (void)poom_arduboy_print(name);
+        }
+        else
+        {
+            poom_arduboy_set_cursor(0, 28);
+            (void)poom_arduboy_print(save_error_text(s_save_status));
+        }
+        poom_arduboy_set_cursor(0, 56);
+        (void)poom_arduboy_print(F("B:BACK"));
     }
     poom_arduboy_display();
 }
@@ -432,18 +482,26 @@ static void menu_picopass_button_cb_(const poom_sbus_msg_t* msg, void* user_ctx)
         else if(ev.button == BTN_DOWN &&
                 (s_status == PoomPicopassOk || s_status == PoomPicopassErrAuth))
         {
-            s_state = PP_INFO;
+            s_sd_probe_pending = true;  // task checks SD before drawing Info
+            s_state            = PP_INFO;
         }
     }
     else if(s_state == PP_INFO)
     {
         if(ev.button == BTN_B)
             s_state = PP_RESULT;
+        else if(ev.button == BTN_UP && s_sd_ok)
+            s_state = PP_SAVING;  // task performs the write
         else if(ev.button == BTN_DOWN)
         {
             s_raw_page = 0;
             s_state    = PP_RAW;
         }
+    }
+    else if(s_state == PP_SAVED)
+    {
+        if(ev.button == BTN_B)
+            s_state = PP_INFO;
     }
     else if(s_state == PP_RAW)
     {
@@ -507,6 +565,23 @@ static void menu_picopass_task_(void* arg)
                 s_state = PP_RESULT;  // hard error (init/select/etc): report it
             }
             continue;
+        }
+
+        if(s_state == PP_SAVING)
+        {
+            pp_draw_();  // show "Saving..." before the (brief) blocking write
+            s_save_status =
+                poom_picopass_save(&s_dump, s_save_path, sizeof(s_save_path));
+            s_state = PP_SAVED;
+            continue;
+        }
+
+        // Probe the SD once on entering Info (off the read path) so the Save
+        // hint only shows when a card is usable.
+        if(s_sd_probe_pending)
+        {
+            s_sd_ok            = poom_picopass_sd_ready();
+            s_sd_probe_pending = false;
         }
 
         pp_draw_();

--- a/applications/poom_picopass/CMakeLists.txt
+++ b/applications/poom_picopass/CMakeLists.txt
@@ -9,6 +9,7 @@ idf_component_register(
     SRCS
         "src/rfal_picopass.c"
         "src/poom_picopass.c"
+        "src/poom_picopass_save.c"
         "src/poom_wiegand.c"
         "src/poom_des.c"
         "src/loclass/optimized_cipher.c"
@@ -23,4 +24,5 @@ idf_component_register(
     REQUIRES
         nfcal
         poom_nfc
+        sd_card
 )

--- a/applications/poom_picopass/include/poom_picopass.h
+++ b/applications/poom_picopass/include/poom_picopass.h
@@ -4,7 +4,10 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+
+#include "esp_err.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,6 +46,13 @@ typedef struct
     uint8_t aia[POOM_PICOPASS_BLOCK_LEN];  // block 5 (application issuer area)
     uint8_t div_key[POOM_PICOPASS_BLOCK_LEN];  // diversified key used for auth
 
+    // Key blocks 3 (Kd) and 4 (Kc), as read back post-auth. Cards mask these,
+    // but they are captured for a faithful dump.
+    uint8_t kd[POOM_PICOPASS_BLOCK_LEN];
+    uint8_t kc[POOM_PICOPASS_BLOCK_LEN];
+    bool kd_valid;
+    bool kc_valid;
+
     bool authenticated;
     uint8_t app_block_count;  // number of valid entries in blocks[]
     uint8_t blocks[POOM_PICOPASS_MAX_APP_BLOCKS]
@@ -77,6 +87,17 @@ PoomPicopassStatus poom_picopass_read(PoomPicopassDump* out,
 
 // Format `dump` as human-readable hex lines into `buf` (returns bytes written).
 int poom_picopass_format(const PoomPicopassDump* dump, char* buf, int buf_len);
+
+// Save `dump` as a Flipper-compatible .picopass file on the SD card under
+// /picopass, auto-named from the CSN. Writes the relative path into
+// `out_rel_path` (if non-NULL). Returns ESP_OK or an ESP error code.
+esp_err_t poom_picopass_save(const PoomPicopassDump* dump,
+                             char* out_rel_path,
+                             size_t out_rel_path_len);
+
+// True if an SD card is mounted (mounting it if needed). Lets the UI hide the
+// save option when there's no usable card. Mounts the card as a side effect.
+bool poom_picopass_sd_ready(void);
 
 // Well-known standard iCLASS debit key.
 extern const uint8_t poom_picopass_standard_key[POOM_PICOPASS_BLOCK_LEN];

--- a/applications/poom_picopass/src/poom_picopass.c
+++ b/applications/poom_picopass/src/poom_picopass.c
@@ -183,6 +183,11 @@ PoomPicopassStatus poom_picopass_read(PoomPicopassDump* out,
     }
     out->authenticated = true;
 
+    // Capture the key blocks (Kd/Kc) now that we're authenticated, so a saved
+    // dump is complete. Cards mask these, but we store whatever they return.
+    out->kd_valid = read_block(POOM_PICOPASS_KD_BLOCK, out->kd) == PoomPicopassOk;
+    out->kc_valid = read_block(POOM_PICOPASS_KC_BLOCK, out->kc) == PoomPicopassOk;
+
     // Read AA1 application blocks from block 6 up to (but not including)
     // app_limit.
     uint8_t last  = out->app_limit;

--- a/applications/poom_picopass/src/poom_picopass_save.c
+++ b/applications/poom_picopass/src/poom_picopass_save.c
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Save a PicoPass dump to the SD card as a Flipper-compatible .picopass file.
+
+#include "poom_picopass.h"
+#include "sd_card.h"
+
+#include <stdio.h>
+
+#define POOM_PICOPASS_DIR "/picopass"
+// Flipper writes at most this many blocks (0..31) into a .picopass file.
+#define POOM_PICOPASS_FILE_MAX_BLOCKS 32
+
+// Data for card block `i`, or NULL when we didn't read it (written as "??").
+static const uint8_t* block_for_index(const PoomPicopassDump* d, int i)
+{
+    switch(i)
+    {
+        case POOM_PICOPASS_CSN_BLOCK:
+            return d->csn;
+        case POOM_PICOPASS_CONFIG_BLOCK:
+            return d->config;
+        case POOM_PICOPASS_EPURSE_BLOCK:
+            return d->epurse;
+        case POOM_PICOPASS_KD_BLOCK:
+            return d->kd_valid ? d->kd : NULL;
+        case POOM_PICOPASS_KC_BLOCK:
+            return d->kc_valid ? d->kc : NULL;
+        case POOM_PICOPASS_AIA_BLOCK:
+            return d->aia;
+        default:
+        {
+            int app = i - POOM_PICOPASS_PACS_CFG_BLOCK;
+            return (app < d->app_block_count) ? d->blocks[app] : NULL;
+        }
+    }
+}
+
+static void fprint_block(FILE* f, const uint8_t* b)
+{
+    for(int j = 0; j < POOM_PICOPASS_BLOCK_LEN; j++)
+    {
+        (void)fprintf(f, "%02X%s", b[j],
+                      (j + 1 < POOM_PICOPASS_BLOCK_LEN) ? " " : "\n");
+    }
+}
+
+bool poom_picopass_sd_ready(void)
+{
+    if(sd_card_is_not_mounted())
+    {
+        sd_card_begin();
+        return sd_card_mount() == ESP_OK;
+    }
+    return true;
+}
+
+esp_err_t poom_picopass_save(const PoomPicopassDump* dump,
+                             char* out_rel_path,
+                             size_t out_rel_path_len)
+{
+    if(dump == NULL)
+        return ESP_ERR_INVALID_ARG;
+
+    esp_err_t err;
+    if(sd_card_is_not_mounted())
+    {
+        sd_card_begin();
+        err = sd_card_mount();
+        if(err != ESP_OK)
+            return err;
+    }
+
+    // sd_card_create_dir takes a FATFS volume-relative path (no /sdcard),
+    // while fopen() below goes through the VFS and needs the /sdcard prefix.
+    err = sd_card_create_dir(POOM_PICOPASS_DIR);
+    if(err != ESP_OK)
+        return err;
+
+    // Name the file after the CSN. Keep the filename component within POOM's
+    // FATFS long-name limit (CONFIG_FATFS_MAX_LFN, 31): 16 hex + ".picopass"
+    // is 25 chars; a longer prefix would overflow and fail to open.
+    char rel[64];
+    (void)snprintf(rel, sizeof(rel),
+                   "%s/%02X%02X%02X%02X%02X%02X%02X%02X.picopass",
+                   POOM_PICOPASS_DIR, dump->csn[0], dump->csn[1], dump->csn[2],
+                   dump->csn[3], dump->csn[4], dump->csn[5], dump->csn[6],
+                   dump->csn[7]);
+
+    char abs[96];
+    (void)snprintf(abs, sizeof(abs), "%s%s", SD_CARD_PATH, rel);
+
+    FILE* f = fopen(abs, "w");
+    if(f == NULL)
+        return ESP_ERR_FILE_OPEN_FAILED;
+
+    (void)fprintf(f, "Filetype: Flipper Picopass device\n");
+    (void)fprintf(f, "Version: 1\n");
+    (void)fprintf(f, "Credential: ");
+    fprint_block(f, dump->credential);
+    (void)fprintf(f, "# Picopass blocks\n");
+
+    int blocks = dump->app_limit;
+    if(blocks > POOM_PICOPASS_FILE_MAX_BLOCKS)
+        blocks = POOM_PICOPASS_FILE_MAX_BLOCKS;
+    for(int i = 0; i < blocks; i++)
+    {
+        const uint8_t* b = block_for_index(dump, i);
+        (void)fprintf(f, "Block %d: ", i);
+        if(b == NULL)
+            (void)fprintf(f, "?? ?? ?? ?? ?? ?? ?? ??\n");
+        else
+            fprint_block(f, b);
+    }
+
+    (void)fclose(f);
+
+    if((out_rel_path != NULL) && (out_rel_path_len > 0U))
+        (void)snprintf(out_rel_path, out_rel_path_len, "%s", rel);
+    return ESP_OK;
+}


### PR DESCRIPTION
Adds saving to the PicoPass reader. Up on the Info screen writes the card to `/picopass/<CSN>.picopass` in Flipper's format, so you can read the dumps on a PC or a Flipper.

- The read now grabs the Kd/Kc key blocks post-auth too, so the file has the full block set; anything we couldn't read is written as `??`.
- Save only shows up when an SD card is mounted (probed once when you open Info, off the read path).
- A failed write says whether there's no card, it needs formatting, or the write failed.

The filename is fixed to the CSN to keep this PR small. On-device naming with a keyboard (`poom_ui_keyboard`) is a planned follow-up.

One gotcha worth noting: POOM caps FATFS filenames at 31 chars (`CONFIG_FATFS_MAX_LFN=31`), so the name is the 16-hex CSN plus `.picopass` (25 chars) with no prefix. A longer name failed to open with EINVAL.

Tested on hardware: read a standard iCLASS card, saved, and confirmed the file on the card.