### PR TITLE
Name saved PicoPass files from the keyboard

### DIFF
--- a/applications/poom_app_pack/src/menu_picopass.c
+++ b/applications/poom_app_pack/src/menu_picopass.c
@@ -5,6 +5,7 @@
 #include "menu_picopass.h"
 #include "poom_nfc_controller.h"  // release the NFC core on exit
 #include "poom_picopass.h"
+#include "poom_ui_keyboard.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -19,7 +20,8 @@
 #include "poom_sbus.h"
 
 #define POOM_MENU_RESUME_TOPIC   "poom/menu/resume"
-#define MENU_PICOPASS_REFRESH_MS (150U)
+#define MENU_PICOPASS_REFRESH_MS    (150U)
+#define MENU_PICOPASS_KB_REFRESH_MS (30U)  // faster redraw while typing a name
 #define MENU_PICOPASS_POLL_MS    (120U)  // gap between read attempts while polling
 #define MENU_PICOPASS_STACK      (8192U)  // read flow + loclass/DES need the stack
 #define MENU_PICOPASS_PRIO       (4U)
@@ -67,9 +69,10 @@ typedef enum
     PP_READING,
     PP_RESULT,
     PP_INFO,    // decoded card metadata (security, key, SIO)
-    PP_RAW,     // paged raw block hex
-    PP_SAVING,  // writing the dump to SD
-    PP_SAVED    // save outcome
+    PP_RAW,      // paged raw block hex
+    PP_KEYBOARD, // entering the save file name
+    PP_SAVING,   // writing the dump to SD
+    PP_SAVED     // save outcome
 } pp_state_t;
 
 // Submenu options. Add real entries (Emulate, Write, ...) here as they land.
@@ -94,6 +97,8 @@ static esp_err_t s_save_status     = ESP_OK;
 static char s_save_path[64]        = {0};
 static bool s_sd_ok                = false;  // SD usable (probed on Info entry)
 static bool s_sd_probe_pending     = false;
+static poom_ui_keyboard_t s_kb;
+static char s_name[POOM_PICOPASS_NAME_MAX + 1];  // save file name being edited
 static PoomPicopassStatus s_status = PoomPicopassOk;
 static PoomPicopassDump s_dump;
 
@@ -182,6 +187,16 @@ static const uint8_t* pp_raw_row(int row, char* label, size_t label_sz)
 
 static void pp_draw_(void)
 {
+    if(s_state == PP_KEYBOARD)
+    {
+        // s_kb is edited on the button-callback thread and read here on the
+        // task thread (like s_state elsewhere in this file); a stale read is at
+        // worst a one-frame glitch. The keyboard draws its own full-screen
+        // modal (clears + displays).
+        poom_ui_keyboard_draw(&s_kb);
+        return;
+    }
+
     poom_arduboy_clear();
     pp_draw_header_();
 
@@ -491,12 +506,27 @@ static void menu_picopass_button_cb_(const poom_sbus_msg_t* msg, void* user_ctx)
         if(ev.button == BTN_B)
             s_state = PP_RESULT;
         else if(ev.button == BTN_UP && s_sd_ok)
-            s_state = PP_SAVING;  // task performs the write
+        {
+            // Start with a blank name; an empty entry falls back to the CSN.
+            s_name[0] = '\0';
+            poom_ui_keyboard_init(&s_kb, s_name, sizeof(s_name), "NAME");
+            s_state = PP_KEYBOARD;
+        }
         else if(ev.button == BTN_DOWN)
         {
             s_raw_page = 0;
             s_state    = PP_RAW;
         }
+    }
+    else if(s_state == PP_KEYBOARD)
+    {
+        // B cancels back to Info; every other button drives the keyboard, and
+        // OK returns ACCEPT to start the save with the entered name.
+        if(ev.button == BTN_B)
+            s_state = PP_INFO;
+        else if(poom_ui_keyboard_handle_button(&s_kb, ev.button) ==
+                POOM_UI_KEYBOARD_ACTION_ACCEPT)
+            s_state = PP_SAVING;
     }
     else if(s_state == PP_SAVED)
     {
@@ -570,8 +600,8 @@ static void menu_picopass_task_(void* arg)
         if(s_state == PP_SAVING)
         {
             pp_draw_();  // show "Saving..." before the (brief) blocking write
-            s_save_status =
-                poom_picopass_save(&s_dump, s_save_path, sizeof(s_save_path));
+            s_save_status = poom_picopass_save(&s_dump, s_name, s_save_path,
+                                               sizeof(s_save_path));
             s_state = PP_SAVED;
             continue;
         }
@@ -585,7 +615,10 @@ static void menu_picopass_task_(void* arg)
         }
 
         pp_draw_();
-        vTaskDelay(pdMS_TO_TICKS(MENU_PICOPASS_REFRESH_MS));
+        // Redraw faster while typing so the keyboard feels responsive.
+        vTaskDelay(pdMS_TO_TICKS(s_state == PP_KEYBOARD
+                                     ? MENU_PICOPASS_KB_REFRESH_MS
+                                     : MENU_PICOPASS_REFRESH_MS));
     }
     s_task = NULL;
     vTaskDelete(NULL);

--- a/applications/poom_picopass/include/poom_picopass.h
+++ b/applications/poom_picopass/include/poom_picopass.h
@@ -16,6 +16,8 @@ extern "C" {
 #define POOM_PICOPASS_BLOCK_LEN      8
 #define POOM_PICOPASS_MAX_APP_BLOCKS 32  // enough for 2KS/16KS AA1 dumps
 #define POOM_PICOPASS_MAX_WIEGAND    2  // 37-bit matches both H10302 and H10304
+// Max save-name length: name (22) + ".picopass" (9) = 31, FATFS's exact limit.
+#define POOM_PICOPASS_NAME_MAX       22
 
 // iCLASS block indices (AA1).
 #define POOM_PICOPASS_CSN_BLOCK      0
@@ -89,9 +91,11 @@ PoomPicopassStatus poom_picopass_read(PoomPicopassDump* out,
 int poom_picopass_format(const PoomPicopassDump* dump, char* buf, int buf_len);
 
 // Save `dump` as a Flipper-compatible .picopass file on the SD card under
-// /picopass, auto-named from the CSN. Writes the relative path into
-// `out_rel_path` (if non-NULL). Returns ESP_OK or an ESP error code.
+// /picopass. `name` is the base filename (no extension); it is sanitized to
+// FAT-safe characters and falls back to the CSN if empty. Writes the relative
+// path into `out_rel_path` (if non-NULL). Returns ESP_OK or an ESP error code.
 esp_err_t poom_picopass_save(const PoomPicopassDump* dump,
+                             const char* name,
                              char* out_rel_path,
                              size_t out_rel_path_len);
 

--- a/applications/poom_picopass/src/poom_picopass_save.c
+++ b/applications/poom_picopass/src/poom_picopass_save.c
@@ -35,6 +35,21 @@ static const uint8_t* block_for_index(const PoomPicopassDump* d, int i)
     }
 }
 
+// Copy `in` into `out` keeping only FAT-safe characters (replacing the rest
+// with '_'), capped so "<name>.picopass" fits the FATFS long-name limit.
+static void sanitize_name(const char* in, char* out, size_t out_cap)
+{
+    size_t j = 0;
+    for(size_t i = 0; in != NULL && in[i] != '\0' && j + 1 < out_cap; i++)
+    {
+        char c    = in[i];
+        bool safe = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                    (c >= '0' && c <= '9') || c == '_' || c == '-' || c == '.';
+        out[j++] = safe ? c : '_';
+    }
+    out[j] = '\0';
+}
+
 static void fprint_block(FILE* f, const uint8_t* b)
 {
     for(int j = 0; j < POOM_PICOPASS_BLOCK_LEN; j++)
@@ -55,6 +70,7 @@ bool poom_picopass_sd_ready(void)
 }
 
 esp_err_t poom_picopass_save(const PoomPicopassDump* dump,
+                             const char* name,
                              char* out_rel_path,
                              size_t out_rel_path_len)
 {
@@ -76,15 +92,19 @@ esp_err_t poom_picopass_save(const PoomPicopassDump* dump,
     if(err != ESP_OK)
         return err;
 
-    // Name the file after the CSN. Keep the filename component within POOM's
-    // FATFS long-name limit (CONFIG_FATFS_MAX_LFN, 31): 16 hex + ".picopass"
-    // is 25 chars; a longer prefix would overflow and fail to open.
+    // Filename is the sanitized name, or the CSN if that comes out empty. The
+    // name is capped at POOM_PICOPASS_NAME_MAX so "<name>.picopass" stays within
+    // POOM's FATFS long-name limit (31); a longer name fails to open.
+    char safe[POOM_PICOPASS_NAME_MAX + 1];
+    sanitize_name(name, safe, sizeof(safe));
+    if(safe[0] == '\0')
+        (void)snprintf(safe, sizeof(safe),
+                       "%02X%02X%02X%02X%02X%02X%02X%02X", dump->csn[0],
+                       dump->csn[1], dump->csn[2], dump->csn[3], dump->csn[4],
+                       dump->csn[5], dump->csn[6], dump->csn[7]);
+
     char rel[64];
-    (void)snprintf(rel, sizeof(rel),
-                   "%s/%02X%02X%02X%02X%02X%02X%02X%02X.picopass",
-                   POOM_PICOPASS_DIR, dump->csn[0], dump->csn[1], dump->csn[2],
-                   dump->csn[3], dump->csn[4], dump->csn[5], dump->csn[6],
-                   dump->csn[7]);
+    (void)snprintf(rel, sizeof(rel), "%s/%s.picopass", POOM_PICOPASS_DIR, safe);
 
     char abs[96];
     (void)snprintf(abs, sizeof(abs), "%s%s", SD_CARD_PATH, rel);


### PR DESCRIPTION
Follow-up to #12. Save now opens POOM's on-screen keyboard (`poom_ui_keyboard`) instead of auto-naming the file after the CSN.

- Up on the Info screen opens the keyboard; type a name, OK writes `/picopass/<name>.picopass`.
- Starts blank, and an empty name falls back to the CSN, so you can still just hit OK for the old behavior.
- B cancels back to Info.

The name is sanitized to FAT-safe characters (the keyboard offers `/` and other symbols) and capped at 22 chars so `<name>.picopass` lands within POOM's 31-char FATFS filename limit (`CONFIG_FATFS_MAX_LFN`).

Same keyboard pattern as `menu_captive`. Redraw speeds up while typing so it stays responsive; the keyboard state is edited on the button-callback thread and read on the draw task, same as the rest of this menu (a stale read is at worst a one-frame glitch).

Tested on hardware: named a card, saved, confirmed the file; empty-name-falls-back-to-CSN and B-cancels both work.